### PR TITLE
Add tests and verify client functions

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,0 +1,48 @@
+import asyncio
+
+from gabriel.core.prompt_template import PromptTemplate
+from gabriel.utils.teleprompter import Teleprompter
+from gabriel.utils import openai_utils
+from gabriel.tasks.simple_rating import SimpleRating, RatingConfig
+from gabriel.tasks.identification import Identification, IdentificationConfig
+
+
+def test_prompt_template():
+    tmpl = PromptTemplate.from_package("ratings_prompt.jinja2")
+    text = tmpl.render(attributes=["a"], descriptions=["desc"], passage="x", object_category="obj", attribute_category="att", format="json")
+    assert "desc" in text
+
+
+def test_teleprompter():
+    tele = Teleprompter()
+    out = tele.generic_elo_prompt(text_circle="a", text_square="b", attributes=["one"], instructions="test")
+    assert "test" in out
+
+
+def test_get_response_dummy():
+    responses, _ = asyncio.run(openai_utils.get_response("hi", use_dummy=True))
+    assert responses and responses[0].startswith("DUMMY")
+
+
+def test_get_all_responses_dummy(tmp_path):
+    df = asyncio.run(openai_utils.get_all_responses(
+        prompts=["a", "b"],
+        identifiers=["1", "2"],
+        save_path=str(tmp_path / "out.csv"),
+        use_dummy=True,
+    ))
+    assert len(df) == 2
+
+
+def test_simple_rating_dummy(tmp_path):
+    cfg = RatingConfig(attributes={"helpfulness": ""}, save_path=str(tmp_path/"out.csv"), use_dummy=True)
+    task = SimpleRating(cfg)
+    df = asyncio.run(task.predict(["hello"]))
+    assert not df.empty
+
+
+def test_identification_dummy(tmp_path):
+    cfg = IdentificationConfig(classes={"yes": "y"}, save_path=str(tmp_path/"out.csv"), use_dummy=True)
+    task = Identification(cfg)
+    df = asyncio.run(task.classify(["who"]))
+    assert not df.empty


### PR DESCRIPTION
## Summary
- add a test suite covering prompts, Teleprompter and dummy OpenAI calls
- test SimpleRating and Identification with dummy responses
- align `get_response` and `get_all_responses` defaults with legacy utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68756ca4830083329679f50cc62d90c7