### PR TITLE
Integrate ratings and de‑identification tasks

### DIFF
--- a/src/gabriel/__init__.py
+++ b/src/gabriel/__init__.py
@@ -1,12 +1,15 @@
 """GABRIEL: LLM-based social science analysis toolkit."""
 
 from .tasks.simple_rating import SimpleRating
+from .tasks.ratings import Ratings
+from .tasks.deidentification import Deidentifier
 from .tasks.elo import EloRater
-
 from .tasks.identification import Identification
 
 __all__ = [
     "SimpleRating",
     "EloRater",
+    "Ratings",
+    "Deidentifier",
     "Identification",
 ]

--- a/src/gabriel/prompts/faceless_prompt.jinja2
+++ b/src/gabriel/prompts/faceless_prompt.jinja2
@@ -1,0 +1,101 @@
+You will be given a block of text belonging to a single individual or group. Your job is to produce or update a JSON mapping from personal or sensitive entities mentioned in the text to anonymized substitutes. Each mapping entry uses a short description of the entity (e.g., "younger son's name", "street address") as the key.
+
+Below is the current mapping dictionary for this group, built from previously processed text chunks. You must preserve all existing entries, adding new real forms of existing entities if they appear in this text, and adding new entries for any additional entities that need anonymization. You may refine a description key (e.g., from "personal name" to "daughter's name") if you learn more detail, but keep the casted form consistent.
+
+Current mapping:
+{{ current_map }}
+
+
+If there is no existing mapping provided above, start a new one from scratch.
+
+By default you should anonymize common personally identifying information, including:
+- Names of the individual and their relatives or close contacts
+- Specific addresses, hometowns, or workplace names that would reveal location
+- Phone numbers, email addresses, credit card or SSN numbers
+Any public figures or information not considered identifying need not be changed.
+Ages also should not be included in the mapping dictionary by default.
+Importantly, all personal details that are not identifying should be retained and not included in the mapping dictionary.
+We don't want to override even very personal and sensitive details; we only wish to anonymize all information that would be easily identifying.
+Someone's hobbies and opinions are not identifying information and should be retained; their name and address are identifying information and should be anonymized.
+Similarly, "my mother" or a common workplace name like "Target" should not be included in the mapping dictionary, only include cases where the term could easily be used to identify an individual, where they live, and other PII.
+{% if guidelines %}
+Follow these additional de-identification guidelines carefully:
+{{ guidelines }}
+The guidelines should be followed strictly, and you should focus on thorough compliance with them. They take precedence over the default instructions.
+{% endif %}
+
+For each entity, output an object with two fields:
+- "real forms": list of verbatim strings exactly as they appear in the text across all processed chunks
+- "casted form": your chosen anonymized substitute, ideally matching the original's style (e.g., similar cultural background for names, similar city for hometown). Choose a conceptually close substitute that conveys the essence of the original entity without revealing the original identity
+
+Example mapping snippet:
+{
+    "younger son's name": {
+        "real forms": ["Tim", "Timmy", "Tim Scott", "T-I-M-O-T-H-Y", "T-I-M ... uh ... O-T-H-Y", "Timothy", "Timthy", "T-Tim"],
+        "casted form": "Blake"
+    },
+    "hometown": {
+        "real forms": ["Lubbock", "Lubbock, Texas"],
+        "casted form": "Medford"
+    },
+    "mother's name": {
+        "real forms": ["Susan", "Sue", "Sue Scott"],
+        "casted form": "Mary"
+    }
+    "workplace name": {
+        "real forms": [
+            "Mayo Clinic", "Mayo-Clinic",
+            "The Mayo Clinic", "mayo hospital", "Mayo Jacksonville",
+            "Mayo Clinic Hospital"
+        ],
+        "casted form": "Orchard Medical Center"
+    }
+}
+
+Here is the text you are to analyze:
+BEGIN TEXT
+{{ text }}
+END TEXT
+
+Current mapping:
+{{ current_map }}
+
+If there is no existing mapping provided above, start a new one from scratch.
+
+{% if guidelines %}
+Follow these additional de-identification guidelines carefully:
+{{ guidelines }}
+The guidelines should be followed strictly, and you should focus on thorough compliance with them.
+{% endif %}
+
+Return the full mapping dictionary as JSON, retaining all existing entries and adding only. Do not include any narrative or explanation outside the JSON object.
+Ensure the real forms are verbatim as they appear in the text.
+The keys like "younger son's name" should be descriptive and concise, as precise as you can confidently make them.
+For example, if a private name is mentioned but not the relationship, you can use "person's name" as the key (and "second person's name" and so on if needed).
+But if you can tell a more specific identifier, like "mother's name" or "doctor's name", use that instead.
+Similarly, if an existing mapping is under "person's name" but you learn it is a "mother's name", you can change the key to "mother's name". This also applies to other entities like addresses, phone numbers, etc.
+Above all, ensure that you never lose any of the existing mapping entries, especially the real forms. Only add new real forms to an existing mapping entry if you discover any new forms for that same entity. 
+If you learn a new entity that should be deidentified, add it as a new entry.
+Be very thorough even if the text is long, capturing all entities you can identify in all forms.
+Ensure you return the full mapping dictionary as JSON, with all the existing entries maintained or updated, and any new ones you add.
+
+Choose casted forms that are conceptually close to the original and carry the same meaning, like a similar sized city or an ethnically similar name.
+Ensure when coming up with casted forms that you have some creativity and would not just use the same exact casted name or address on a different text.
+Unless you have been provided additional guidelines that override the default, use common sense by default and don't overclassify non-sensitive information. Don't include ages in the mapping dictionary by default, don't put anything in the mapping that is not sensitive or personal, and there is no point in mapping something to itself.
+Keep to a convention like "person's name", "second person's name", "third person's name" or "child's name", "second child's name", "third child's name" etc if you have multiple names to map and can't tell the relationships more specifically.
+Be thorough and careful but don't overclassify either.
+
+It is crucial that all forms of the same entity are captured in the mapping, so be sure to include all variations and spellings of the same entity that appear in the text, including nicknames, abbreviations, forms where the name is spelled out letter by letter (e.g. "E-M-I-L-Y"), and even misspellings in their exact mispelled form. Any and all forms must be documented in the mapping dictionary.
+This is important because we need to ultimately use this mapping to deidentify the text, and if we miss any forms of an entity, it could lead to reidentification.
+Pay close attention to whether a mispelled or oddly formatted form of an entity is present in the text, and be sure to include all such unusual forms in the mapping dictionary. Same for any abbreviations or acronyms that are used in the text, especially for workplaces or organizations.
+It is also important to ensure that you are confident all real forms for an entity are for that one same entity. If in doubt, you can always add a new entry for a new entity.
+If you realize there is misorgnization or wrong mappings in the existing mapping, you can fix it.
+You can reorganize and redo the mappings as much as needed, as long as all real forms from the existing mapping are somewhere in the new mapping, even if you move them around or change the keys.
+That said, only make changes if you are reasonably confident in them.
+
+Again, remember only de-identify sensitive information and retain all non-identifying details.
+Public figures (celebrity or politician names etc.) should not be anonymized.
+Common workplaces (e.g. Walmart, Uber, TaskRabbit, etc.) should not be anonymized -- only location specific workplaces like "Mayo Clinic" or "Pinocchio's Pizza" should be anonymized.
+Age should not be included in the mapping dictionary by default.
+Terms like "my mother" or "my mom" or "Dad" or "my workplace" or "email address" must not be included in the mapping dictionary, only include cases where the actual person's or entity's identifying name is used.
+Only map terms that are identifying; this is a fairly narrow set of terms and most personal details should be retained.

--- a/src/gabriel/prompts/ratings_prompt.jinja2
+++ b/src/gabriel/prompts/ratings_prompt.jinja2
@@ -32,11 +32,6 @@ Remember, the attributes you are rating are {{ attribute_list }}.
 Ensure you provide a rating for every single one of these attributes, and do not modify them in any way.
 You should have as many ratings as there are attributes, and you should not alter the attribute name in any fashion.
 
-{% if format == 'table' %}
-Format:
-| Attribute | {% for attribute in attributes %} | {{ attribute }} {% endfor %} |
-| Response  | {% for _ in attributes %} | <insert rating for attribute> {% endfor %} |
-{% elif format == 'json' %}
 {
   "data": [
     {% for attribute in attributes %}
@@ -47,12 +42,3 @@ Format:
     {% endfor %}
   ]
 }
-{% else %}
-Format as list:
-{% for attribute in attributes %}
-Column {{ loop.index }}
-Attribute {{ loop.index }}: {{ attribute }}
-Rating for Attribute {{ loop.index }}: <insert rating for attribute here>
-
-{% endfor %}
-{% endif %}

--- a/src/gabriel/tasks/__init__.py
+++ b/src/gabriel/tasks/__init__.py
@@ -1,7 +1,15 @@
 """Task implementations for GABRIEL."""
 
 from .simple_rating import SimpleRating
+from .ratings import Ratings
+from .deidentification import Deidentifier
 from .elo import EloRater
 from .identification import Identification
 
-__all__ = ["SimpleRating", "EloRater", "Identification"]
+__all__ = [
+    "SimpleRating",
+    "Ratings",
+    "Deidentifier",
+    "EloRater",
+    "Identification",
+]

--- a/src/gabriel/tasks/deidentification.py
+++ b/src/gabriel/tasks/deidentification.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+import pandas as pd
+
+from ..core.prompt_template import PromptTemplate
+from ..utils.openai_utils import get_all_responses
+
+
+@dataclass
+class DeidentifyConfig:
+    """Configuration for :class:`Deidentifier`."""
+
+    model: str = "gpt-3.5-turbo"
+    n_parallels: int = 50
+    save_path: str = "deidentified.csv"
+    use_dummy: bool = False
+    timeout: float = 60.0
+    max_words_per_call: int = 7500
+    guidelines: str = ""
+
+
+class Deidentifier:
+    """Iterative de-identification of sensitive entities in text."""
+
+    def __init__(self, cfg: DeidentifyConfig, template: PromptTemplate | None = None) -> None:
+        self.cfg = cfg
+        self.template = template or PromptTemplate.from_package("faceless_prompt.jinja2")
+
+    @staticmethod
+    def _chunk_by_words(text: str, max_words: int) -> List[str]:
+        words = text.split()
+        if len(words) <= max_words:
+            return [text]
+        return [" ".join(words[i : i + max_words]) for i in range(0, len(words), max_words)]
+
+    @staticmethod
+    def _parse_json(txt: str) -> Dict[str, dict]:
+        try:
+            return json.loads(txt)
+        except Exception:
+            try:
+                match = re.search(r"\{[\s\S]*\}", txt)
+                if match:
+                    return json.loads(match.group(0))
+            except Exception:
+                pass
+        return {}
+
+    async def run(
+        self,
+        df: pd.DataFrame,
+        text_column: str,
+        grouping_column: Optional[str] = None,
+    ) -> pd.DataFrame:
+        """Deidentify all texts in ``df[text_column]``.
+
+        A ``grouping_column`` can be provided to ensure that the mapping is built
+        across multiple rows belonging to the same group.
+        """
+        df_proc = df.reset_index(drop=True).copy()
+        if grouping_column is None:
+            df_proc["group_id"] = df_proc.index.astype(str)
+        else:
+            df_proc["group_id"] = df_proc[grouping_column].astype(str)
+
+        group_ids = df_proc["group_id"].unique().tolist()
+        group_segments: Dict[str, List[str]] = {}
+        for gid in group_ids:
+            segs: List[str] = []
+            texts = (
+                df_proc.loc[df_proc["group_id"] == gid, text_column]
+                .fillna("")
+                .astype(str)
+                .tolist()
+            )
+            for text in texts:
+                segs.extend(self._chunk_by_words(text, self.cfg.max_words_per_call))
+            group_segments[gid] = segs
+
+        group_to_map: Dict[str, dict] = {gid: {} for gid in group_ids}
+        max_rounds = max(len(s) for s in group_segments.values()) if group_segments else 0
+
+        for rnd in range(max_rounds):
+            prompts: List[str] = []
+            identifiers: List[str] = []
+            active_gids: List[str] = []
+            for gid in group_ids:
+                segs = group_segments[gid]
+                if rnd < len(segs):
+                    prompts.append(
+                        self.template.render(
+                            text=segs[rnd],
+                            current_map=json.dumps(group_to_map[gid], ensure_ascii=False),
+                            guidelines=self.cfg.guidelines,
+                        )
+                    )
+                    identifiers.append(f"{gid}_seg_{rnd}")
+                    active_gids.append(gid)
+            if not prompts:
+                continue
+            batch_df = await get_all_responses(
+                prompts=prompts,
+                identifiers=identifiers,
+                n_parallels=self.cfg.n_parallels,
+                model=self.cfg.model,
+                save_path=f"{os.path.splitext(self.cfg.save_path)[0]}_round{rnd}.csv",
+                use_dummy=self.cfg.use_dummy,
+                timeout=self.cfg.timeout,
+                json_mode=True,
+            )
+            for ident, resp in zip(batch_df["Identifier"], batch_df["Response"]):
+                gid = ident.split("_seg_")[0]
+                main = resp[0] if isinstance(resp, list) and resp else ""
+                parsed = self._parse_json(main)
+                if parsed:
+                    group_to_map[gid] = parsed
+
+        mappings_col: List[dict] = []
+        deidentified_texts: List[str] = []
+        for _, row in df_proc.iterrows():
+            gid = row["group_id"]
+            mapping = group_to_map.get(gid, {})
+            mappings_col.append(mapping)
+            text = str(row[text_column])
+            deid_text = text
+            pairs: List[tuple[str, str]] = []
+            for entry in mapping.values():
+                if isinstance(entry, dict):
+                    casted = entry.get("casted form", "")
+                    for real in entry.get("real forms", []):
+                        pairs.append((real, casted))
+            pairs.sort(key=lambda x: len(x[0]), reverse=True)
+            for real, casted in pairs:
+                pattern = re.compile(rf"\b{re.escape(real)}\b", flags=re.IGNORECASE)
+                deid_text = pattern.sub(casted, deid_text)
+            deidentified_texts.append(deid_text)
+
+        df_proc["mapping"] = mappings_col
+        df_proc["deidentified_text"] = deidentified_texts
+        df_proc.to_csv(self.cfg.save_path, index=False)
+        return df_proc

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,9 +1,12 @@
 import asyncio
+import pandas as pd
 
 from gabriel.core.prompt_template import PromptTemplate
 from gabriel.utils.teleprompter import Teleprompter
 from gabriel.utils import openai_utils
 from gabriel.tasks.simple_rating import SimpleRating, RatingConfig
+from gabriel.tasks.ratings import Ratings, RatingsConfig
+from gabriel.tasks.deidentification import Deidentifier, DeidentifyConfig
 from gabriel.tasks.identification import Identification, IdentificationConfig
 
 
@@ -39,6 +42,21 @@ def test_simple_rating_dummy(tmp_path):
     task = SimpleRating(cfg)
     df = asyncio.run(task.predict(["hello"]))
     assert not df.empty
+
+
+def test_ratings_dummy(tmp_path):
+    cfg = RatingsConfig(attributes={"helpfulness": ""}, save_path=str(tmp_path/"ratings.csv"), use_dummy=True)
+    task = Ratings(cfg)
+    df = asyncio.run(task.run(["hello"]))
+    assert not df.empty
+
+
+def test_deidentifier_dummy(tmp_path):
+    cfg = DeidentifyConfig(save_path=str(tmp_path/"deid.csv"), use_dummy=True)
+    task = Deidentifier(cfg)
+    data = pd.DataFrame({"text": ["John went to Paris."]})
+    df = asyncio.run(task.run(data, text_column="text"))
+    assert "deidentified_text" in df.columns
 
 
 def test_identification_dummy(tmp_path):


### PR DESCRIPTION
## Summary
- streamline ratings prompt to always use JSON
- add new `Ratings` task for batch attribute ratings
- add new `Deidentifier` task for iterative de‑identification
- expose new tasks in package API
- test new functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687575cde07083328ef5ecc16baf25a9