### PR TITLE
Fix packaging configuration and lazy import

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling>=1.21"]
 build-backend = "hatchling.build"
 
 [project]
@@ -20,8 +20,8 @@ dependencies = [
     "aiolimiter>=1.0.0"
 ]
 
+[tool.hatch.build.targets.wheel]
+packages = ["src/gabriel"]
+
 [tool.hatch.build]
-packages = [
-    {include = "gabriel", from = "src"}
-]
 include = ["src/gabriel/prompts/*.jinja2", "src/gabriel/prompts/*.yaml"]

--- a/src/gabriel/__init__.py
+++ b/src/gabriel/__init__.py
@@ -1,10 +1,11 @@
 """GABRIEL: LLM-based social science analysis toolkit."""
 
-from .tasks.simple_rating import SimpleRating
-from .tasks.ratings import Ratings
-from .tasks.deidentification import Deidentifier
-from .tasks.elo import EloRater
-from .tasks.identification import Identification
+from importlib.metadata import PackageNotFoundError, version as _v
+
+try:
+    __version__ = _v("gabriel")
+except PackageNotFoundError:  # pragma: no cover - package not installed
+    __version__ = "0.0.0"
 
 __all__ = [
     "SimpleRating",
@@ -13,3 +14,26 @@ __all__ = [
     "Deidentifier",
     "Identification",
 ]
+
+def __getattr__(name: str):
+    if name == "SimpleRating":
+        from .tasks.simple_rating import SimpleRating
+
+        return SimpleRating
+    if name == "EloRater":
+        from .tasks.elo import EloRater
+
+        return EloRater
+    if name == "Ratings":
+        from .tasks.ratings import Ratings
+
+        return Ratings
+    if name == "Deidentifier":
+        from .tasks.deidentification import Deidentifier
+
+        return Deidentifier
+    if name == "Identification":
+        from .tasks.identification import Identification
+
+        return Identification
+    raise AttributeError(name)


### PR DESCRIPTION
## Summary
- fix hatchling config for package discovery
- make package imports lazy to avoid build-time dependencies

## Testing
- `python -m pip install -e .[dev]`
- `pytest -q`
- `python -m build`

------
https://chatgpt.com/codex/tasks/task_e_68758f93c2ac833288dc34751adf263f