### PR TITLE
Fix wheel build configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,4 @@ dependencies = [
 ]
 
 [tool.hatch.build.targets.wheel]
-packages = ["gabriel"]
-[tool.hatch.build.sources]          # ← add this block
-gabriel = "src/gabriel"             # import-name   :   filesystem-path
+packages = ["src/gabriel"]


### PR DESCRIPTION
## Summary
- ensure the wheel includes source files by referencing `src/gabriel` directly

## Testing
- `pip install -e .`
- `pytest -q`
- `python -m build`

------
https://chatgpt.com/codex/tasks/task_e_6875a4d2ac448332ad27e9657de4a7b7