### PR TITLE
Integrate BasicClassifier into library

### DIFF
--- a/src/gabriel/prompts/basic_classifier_prompt.jinja2
+++ b/src/gabriel/prompts/basic_classifier_prompt.jinja2
@@ -1,0 +1,45 @@
+Your task is to read the following passage and decide which, if any, of the following classification labels apply to it.
+
+**Passage:** 
+
+BEGIN PASSAGE
+{{ text }}
+END PASSAGE
+
+**Classification labels:**
+
+Here is a list of the classification labels you can choose from: {{ labels.keys() }}
+
+{% set has_definitions = labels.values() | select | list | length > 0 %}
+{% if has_definitions %}
+Here are the definitions of each label:
+{% for label, definition in labels.items() %}
+- "{{ label }}" – {{ definition }}
+{% endfor %}
+
+Ground your analysis in the definitions provided above.
+Interpret whether the label applies to the passage based on the specific definition provided, not the general meaning of the label.
+{% endif %}
+
+{% if additional_instructions %}
+
+**Additional instructions:**
+{{ additional_instructions }}
+{% endif %}
+
+**Output format:**
+Return a JSON object mapping each label to either true or false. Example format:
+
+{
+    "label one": true,
+    "label two": false,
+    ...
+}
+
+You must substitute "label one" etc with the exact verbatim label term from the list above. Just the term, exactly as it appears in the list, not the definition.
+You must perform a thorough, independent classification on each and every label; do not leave any label out.
+Again, the list of labels you are considering are: {{ labels.keys() }}
+All could be false (meaning none of the labels apply), all could be true (meaning all of the labels apply), or some combination of true and false.
+Be diligent in thinking hard about each label and whether it applies to the passage.
+Ensure every label is verbatim used as the keys in the output JSON, and the values are boolean (true or false) based on whether the label applies to the passage.
+One more time: the labels you are evaluating on the passage are: {{ labels.keys() }}

--- a/src/gabriel/tasks/__init__.py
+++ b/src/gabriel/tasks/__init__.py
@@ -8,6 +8,7 @@ _lazy_imports = {
     "Deidentifier": ".deidentification",
     "EloRater": ".elo",
     "Identification": ".identification",
+    "BasicClassifier": ".basic_classifier",
 }
 
 __all__ = list(_lazy_imports.keys())

--- a/src/gabriel/tasks/basic_classifier.py
+++ b/src/gabriel/tasks/basic_classifier.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import ast
+import hashlib
+import json
+import os
+import re
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Any, DefaultDict, Dict, List, Optional
+
+import pandas as pd
+
+from ..core.prompt_template import PromptTemplate
+from ..utils.openai_utils import get_all_responses
+
+
+@dataclass
+class BasicClassifierConfig:
+    labels: Dict[str, str]
+    save_dir: str = "classifier"
+    model: str = "gpt-3.5-turbo"
+    n_parallels: int = 400
+    additional_instructions: str = ""
+    use_dummy: bool = False
+    timeout: float = 60.0
+
+
+class BasicClassifier:
+    """Robust passage classifier using an LLM."""
+
+    _FENCE_RE = re.compile(r"```(?:json)?\s*(.*?)\s*```", re.S)
+
+    @staticmethod
+    def _safe_json(txt: Any) -> dict:
+        try:
+            if isinstance(txt, dict):
+                return txt
+            if isinstance(txt, list):
+                if txt and isinstance(txt[0], dict):
+                    return txt[0]
+                if txt and isinstance(txt[0], str):
+                    txt = txt[0]
+            cleaned = str(txt).strip()
+            if (cleaned.startswith('"') and cleaned.endswith('"')) or (
+                cleaned.startswith("'") and cleaned.endswith("'")
+            ):
+                cleaned = cleaned[1:-1]
+            try:
+                return json.loads(cleaned)
+            except Exception:
+                try:
+                    return ast.literal_eval(cleaned)
+                except Exception:
+                    return {}
+        except Exception:
+            return {}
+
+    def __init__(self, cfg: BasicClassifierConfig, template: PromptTemplate | None = None) -> None:
+        self.cfg = cfg
+        self.template = template or PromptTemplate.from_package(
+            "basic_classifier_prompt.jinja2"
+        )
+        os.makedirs(cfg.save_dir, exist_ok=True)
+
+    def _build(self, df: pd.DataFrame, text_col: str):
+        prompts: List[str] = []
+        ids: List[str] = []
+        id_to_rows: DefaultDict[str, List[int]] = defaultdict(list)
+        for row, txt in df[text_col].astype(str).items():
+            clean = " ".join(txt.split())
+            sha8 = hashlib.sha1(clean.encode()).hexdigest()[:8]
+            id_to_rows[sha8].append(row)
+            if len(id_to_rows[sha8]) > 1:
+                continue
+            prompts.append(
+                self.template.render(
+                    text=txt,
+                    labels=self.cfg.labels,
+                    additional_instructions=self.cfg.additional_instructions,
+                )
+            )
+            ids.append(sha8)
+        dup_ct = len(df) - len(prompts)
+        if dup_ct:
+            print(f"[BasicClassifier] Skipped {dup_ct} duplicate prompt(s).")
+        return prompts, ids, id_to_rows
+
+    @staticmethod
+    def _regex(raw: str, labels: Dict[str, str]) -> Dict[str, Optional[bool]]:
+        out: Dict[str, Optional[bool]] = {}
+        for lab in labels:
+            pat = re.compile(rf'\s*"?\s*{re.escape(lab)}\s*"?\s*:\s*(true|false)', re.I | re.S)
+            m = pat.search(raw)
+            out[lab] = None if not m else m.group(1).lower() == "true"
+        return out
+
+    def _parse(self, resp: Any) -> Dict[str, Optional[bool]]:
+        if isinstance(resp, list) and len(resp) == 1:
+            resp = resp[0]
+        if isinstance(resp, (bytes, bytearray)):
+            resp = resp.decode()
+        if isinstance(resp, str):
+            m = self._FENCE_RE.search(resp)
+            if m:
+                resp = m.group(1).strip()
+        data = self._safe_json(resp)
+        if isinstance(data, dict):
+            norm = {
+                k.strip().lower(): (
+                    True
+                    if str(v).strip().lower() in {"true", "yes", "1"}
+                    else False
+                    if str(v).strip().lower() in {"false", "no", "0"}
+                    else None
+                )
+                for k, v in data.items()
+            }
+            return {lab: norm.get(lab.lower(), None) for lab in self.cfg.labels}
+        return self._regex(str(resp), self.cfg.labels)
+
+    async def run(
+        self, df: pd.DataFrame, text_column: str, *, reset_files: bool = False, **kwargs: Any
+    ) -> pd.DataFrame:
+        prompts, ids, id_to_rows = self._build(df, text_column)
+        csv_path = os.path.join(self.cfg.save_dir, "basic_classifier_responses.csv")
+
+        df_resp = await get_all_responses(
+            prompts=prompts,
+            identifiers=ids,
+            n_parallels=self.cfg.n_parallels,
+            save_path=csv_path,
+            reset_files=reset_files,
+            json_mode=True,
+            model=self.cfg.model,
+            use_dummy=self.cfg.use_dummy,
+            timeout=self.cfg.timeout,
+            print_example_prompt=True,
+            **kwargs,
+        )
+        if not isinstance(df_resp, pd.DataFrame):
+            raise RuntimeError("get_all_responses returned no DataFrame")
+
+        parsed_master = {idx: {lab: None for lab in self.cfg.labels} for idx in df.index}
+        orphans = 0
+        for ident, raw in zip(df_resp.Identifier, df_resp.Response):
+            if ident not in id_to_rows:
+                orphans += 1
+                continue
+            parsed = self._parse(raw)
+            for row in id_to_rows[ident]:
+                parsed_master[row] = parsed
+
+        filled = sum(any(v is not None for v in d.values()) for d in parsed_master.values())
+        if orphans:
+            print(
+                f"[BasicClassifier] WARNING: {orphans} response(s) had no matching passage this run."
+            )
+        print(f"[BasicClassifier] Filled {filled}/{len(parsed_master)} rows.")
+
+        parsed_df = pd.DataFrame.from_dict(parsed_master, orient="index")
+
+        total = len(parsed_df)
+        print("\n=== Label coverage (non-null) ===")
+        for lab in self.cfg.labels:
+            n = parsed_df[lab].notna().sum()
+            print(f"{lab:<55s}: {n / total:6.2%} ({n}/{total})")
+        print("=================================\n")
+
+        return df.join(parsed_df, how="left")
+

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -8,6 +8,7 @@ from gabriel.tasks.simple_rating import SimpleRating, RatingConfig
 from gabriel.tasks.ratings import Ratings, RatingsConfig
 from gabriel.tasks.deidentification import Deidentifier, DeidentifyConfig
 from gabriel.tasks.identification import Identification, IdentificationConfig
+from gabriel.tasks.basic_classifier import BasicClassifier, BasicClassifierConfig
 
 
 def test_prompt_template():
@@ -64,3 +65,11 @@ def test_identification_dummy(tmp_path):
     task = Identification(cfg)
     df = asyncio.run(task.classify(["who"]))
     assert not df.empty
+
+def test_basic_classifier_dummy(tmp_path):
+    cfg = BasicClassifierConfig(labels={"yes": ""}, save_dir=str(tmp_path), use_dummy=True)
+    task = BasicClassifier(cfg)
+    df = pd.DataFrame({"txt": ["a", "b"]})
+    res = asyncio.run(task.run(df, text_column="txt"))
+    assert "yes" in res.columns
+


### PR DESCRIPTION
## Summary
- add original `basic_classifier_prompt.jinja2` to packaged prompts
- implement new `BasicClassifier` task based on standalone classifier logic
- expose `BasicClassifier` via `gabriel.tasks`
- test the new task in dummy mode

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68768fed7a8483329f01f8466599d683