### PR TITLE
Default model now o4-mini

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The full list of parameters for the function is as follows.
 -**`truncate_len`** (optional, defaults to 5000) the amount of text to keep. 
 - **`project_probs`** (optional, defaults to False): Whether to project the probabilities from 0 to 100 to a 0 to 1 scale.
 - **`api_key`** (mandatory): Your OpenAI API key.
-- **`model`** (optional): Backend model, default = `gpt-3.5-turbo-1106`.
+- **`model`** (optional): Backend model, default = `o4-mini`.
 - **`seed`** (optional, RECOMMENDED): Set a seed for cross-run replicability. For instance, `seed = 0`.
 
 ## Citation

--- a/src/gabriel/tasks/basic_classifier.py
+++ b/src/gabriel/tasks/basic_classifier.py
@@ -19,7 +19,7 @@ from ..utils.openai_utils import get_all_responses
 class BasicClassifierConfig:
     labels: Dict[str, str]
     save_dir: str = "classifier"
-    model: str = "gpt-3.5-turbo"
+    model: str = "o4-mini"
     n_parallels: int = 400
     additional_instructions: str = ""
     use_dummy: bool = False

--- a/src/gabriel/tasks/deidentification.py
+++ b/src/gabriel/tasks/deidentification.py
@@ -16,7 +16,7 @@ from ..utils.openai_utils import get_all_responses
 class DeidentifyConfig:
     """Configuration for :class:`Deidentifier`."""
 
-    model: str = "gpt-3.5-turbo"
+    model: str = "o4-mini"
     n_parallels: int = 50
     save_path: str = "deidentified.csv"
     use_dummy: bool = False

--- a/src/gabriel/tasks/ratings.py
+++ b/src/gabriel/tasks/ratings.py
@@ -24,7 +24,7 @@ from ..utils.openai_utils import get_all_responses
 @dataclass
 class RatingsConfig:
     attributes: Dict[str, str]          # {"clarity": "description", ...}
-    model: str = "gpt-3.5-turbo"
+    model: str = "o4-mini"
     n_parallels: int = 50
     save_path: str = "ratings.csv"
     use_dummy: bool = False

--- a/src/gabriel/utils/openai_utils.py
+++ b/src/gabriel/utils/openai_utils.py
@@ -65,7 +65,7 @@ def _build_params(
 async def get_response(
     prompt: str,
     *,
-    model: str = "gpt-4.1-mini",
+    model: str = "o4-mini",
     n: int = 1,
     max_tokens: int = 25_000,
     timeout: float = 90.0,


### PR DESCRIPTION
## Summary
- use `o4-mini` as default model in all tasks
- update openai helper default to `o4-mini`
- document new default model in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876cc982130833293e638cb1bc484c3