### PR TITLE
Add PromptParaphraser utility

### DIFF
--- a/src/gabriel/prompts/prompt_paraphraser_prompt.jinja2
+++ b/src/gabriel/prompts/prompt_paraphraser_prompt.jinja2
@@ -1,0 +1,17 @@
+You are an expert prompt engineer. Rewrite the provided baseline prompt so that it conveys the exact same instructions using different wording. The goal is to avoid overfitting to a single phrasing while keeping the semantics and output requirements identical.
+
+Guidelines for rewriting:
+- Preserve every instruction, detail and placeholder from the baseline prompt.
+- Rephrase sentences with synonyms or different structure.
+- You may reorder paragraphs or bullet points but keep the meaning.
+- Do not change the required output format or add new information.
+- Keep any markup such as Markdown headings intact when present.
+- Maintain placeholders like {{ variable }} exactly as written.
+- The paraphrased prompt should be roughly the same length as the original.
+
+Below is the baseline prompt:
+"""
+{{ baseline_prompt }}
+"""
+
+Return only the new paraphrased prompt text and nothing else.

--- a/src/gabriel/utils/__init__.py
+++ b/src/gabriel/utils/__init__.py
@@ -4,6 +4,7 @@ from .openai_utils import get_response, get_all_responses
 from .logging import get_logger
 from .teleprompter import Teleprompter
 from .maps import create_county_choropleth
+from .prompt_paraphraser import PromptParaphraser, PromptParaphraserConfig
 
 __all__ = [
     "get_response",
@@ -11,4 +12,6 @@ __all__ = [
     "get_logger",
     "Teleprompter",
     "create_county_choropleth",
+    "PromptParaphraser",
+    "PromptParaphraserConfig",
 ]

--- a/src/gabriel/utils/prompt_paraphraser.py
+++ b/src/gabriel/utils/prompt_paraphraser.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import copy
+import os
+from dataclasses import dataclass
+from typing import Any, List, Type
+
+import pandas as pd
+
+from ..core.prompt_template import PromptTemplate
+from .openai_utils import get_all_responses
+
+
+@dataclass
+class PromptParaphraserConfig:
+    """Configuration for :class:`PromptParaphraser`."""
+
+    n_variants: int = 3
+    model: str = "o4-mini"
+    n_parallels: int = 25
+    save_dir: str = "paraphraser"
+    use_dummy: bool = False
+    timeout: float = 60.0
+
+
+class PromptParaphraser:
+    """Generate paraphrased versions of a task prompt and rerun the task."""
+
+    def __init__(self, cfg: PromptParaphraserConfig, template: PromptTemplate | None = None) -> None:
+        self.cfg = cfg
+        self.template = template or PromptTemplate.from_package("prompt_paraphraser_prompt.jinja2")
+        os.makedirs(self.cfg.save_dir, exist_ok=True)
+
+    async def _paraphrase(self, prompt_text: str) -> List[str]:
+        prompts = [self.template.render(baseline_prompt=prompt_text) for _ in range(self.cfg.n_variants)]
+        ids = [f"variant_{i}" for i in range(1, self.cfg.n_variants + 1)]
+        csv_path = os.path.join(self.cfg.save_dir, "paraphrases.csv")
+        df = await get_all_responses(
+            prompts=prompts,
+            identifiers=ids,
+            n_parallels=self.cfg.n_parallels,
+            model=self.cfg.model,
+            save_path=csv_path,
+            reset_files=True,
+            use_dummy=self.cfg.use_dummy,
+            timeout=self.cfg.timeout,
+        )
+        return [resp[0] if isinstance(resp, list) else resp for resp in df.Response]
+
+    async def run(
+        self,
+        task_cls: Type[Any],
+        task_cfg: Any,
+        *run_args: Any,
+        template: PromptTemplate | None = None,
+        **run_kwargs: Any,
+    ) -> pd.DataFrame:
+        base_template = template or getattr(task_cls(task_cfg), "template")
+        variants = await self._paraphrase(base_template.text)
+
+        results = []
+
+        base_task = task_cls(task_cfg, template=base_template)
+        df_base = await base_task.run(*run_args, **run_kwargs)
+        df_base = df_base.copy()
+        df_base["prompt_variant"] = "baseline"
+        results.append(df_base)
+
+        for idx, text in enumerate(variants, start=1):
+            variant_template = PromptTemplate(text)
+            cfg_variant = copy.deepcopy(task_cfg)
+            if hasattr(cfg_variant, "save_path"):
+                base, ext = os.path.splitext(cfg_variant.save_path)
+                cfg_variant.save_path = f"{base}_p{idx}{ext}"
+            if hasattr(cfg_variant, "save_dir"):
+                cfg_variant.save_dir = os.path.join(cfg_variant.save_dir, f"variant_{idx}")
+                os.makedirs(cfg_variant.save_dir, exist_ok=True)
+            task = task_cls(cfg_variant, template=variant_template)
+            df = await task.run(*run_args, **run_kwargs)
+            df = df.copy()
+            df["prompt_variant"] = f"variant_{idx}"
+            results.append(df)
+
+        return pd.concat(results, ignore_index=True)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -9,6 +9,7 @@ from gabriel.tasks.deidentification import Deidentifier, DeidentifyConfig
 from gabriel.tasks.basic_classifier import BasicClassifier, BasicClassifierConfig
 from gabriel.tasks.regional import Regional, RegionalConfig
 from gabriel.tasks.county_counter import CountyCounter
+from gabriel.utils import PromptParaphraser, PromptParaphraserConfig
 
 
 def test_prompt_template():
@@ -82,4 +83,16 @@ def test_county_counter_dummy(tmp_path):
     )
     df = asyncio.run(counter.run())
     assert "econ" in df.columns
+
+
+def test_prompt_paraphraser_ratings(tmp_path):
+    cfg = RatingsConfig(
+        attributes={"quality": ""},
+        save_path=str(tmp_path / "rat.csv"),
+        use_dummy=True,
+    )
+    parap_cfg = PromptParaphraserConfig(n_variants=2, save_dir=str(tmp_path / "para"), use_dummy=True)
+    paraphraser = PromptParaphraser(parap_cfg)
+    df = asyncio.run(paraphraser.run(Ratings, cfg, ["hello"]))
+    assert set(df.prompt_variant) == {"baseline", "variant_1", "variant_2"}
 


### PR DESCRIPTION
## Summary
- add new prompt template to generate paraphrased prompts
- add `PromptParaphraser` utility to create paraphrased prompt variants and rerun tasks
- expose new utility from `gabriel.utils`
- test paraphraser against Ratings task

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876e94391c08332a5f404321da24258