### PR TITLE
Add rating scale & guidelines options

### DIFF
--- a/legacy_v0/faceless_prompt.jinja2
+++ b/legacy_v0/faceless_prompt.jinja2
@@ -24,6 +24,11 @@ Follow these additional de-identification guidelines carefully:
 The guidelines should be followed strictly, and you should focus on thorough compliance with them. They take precedence over the default instructions.
 {% endif %}
 
+{% if additional_guidelines %}
+In addition, please take the following into account:
+{{ additional_guidelines }}
+{% endif %}
+
 For each entity, output an object with two fields:
 - "real forms": list of verbatim strings exactly as they appear in the text across all processed chunks
 - "casted form": your chosen anonymized substitute, ideally matching the original's style (e.g., similar cultural background for names, similar city for hometown). Choose a conceptually close substitute that conveys the essence of the original entity without revealing the original identity
@@ -66,6 +71,11 @@ If there is no existing mapping provided above, start a new one from scratch.
 Follow these additional de-identification guidelines carefully:
 {{ guidelines }}
 The guidelines should be followed strictly, and you should focus on thorough compliance with them.
+{% endif %}
+
+{% if additional_guidelines %}
+In addition, please take the following into account:
+{{ additional_guidelines }}
 {% endif %}
 
 Return the full mapping dictionary as JSON, retaining all existing entries and adding only. Do not include any narrative or explanation outside the JSON object.

--- a/legacy_v0/generic_elo_prompt.jinja2
+++ b/legacy_v0/generic_elo_prompt.jinja2
@@ -4,6 +4,11 @@ You will be shown two passages labelled *passage circle* and *passage square*. F
 {{ instructions }}
 {% endif %}
 
+{% if additional_guidelines %}
+In addition, please take the following into account:
+{{ additional_guidelines }}
+{% endif %}
+
 **Passage circle**
 BEGIN CIRCLE
 {{ text_circle }}

--- a/regional_analysis_prompt.jinja2
+++ b/regional_analysis_prompt.jinja2
@@ -38,3 +38,8 @@ Topic: {{ topic }}
 **Additional instructions**
 {{ additional_instructions }}
 {% endif %}
+
+{% if additional_guidelines %}
+In addition, please take the following into account:
+{{ additional_guidelines }}
+{% endif %}

--- a/src/gabriel/prompts/basic_classifier_prompt.jinja2
+++ b/src/gabriel/prompts/basic_classifier_prompt.jinja2
@@ -27,6 +27,11 @@ Interpret whether the label applies to the passage based on the specific definit
 {{ additional_instructions }}
 {% endif %}
 
+{% if additional_guidelines %}
+In addition, please take the following into account:
+{{ additional_guidelines }}
+{% endif %}
+
 **Output format:**
 Return a JSON object mapping each label to either true or false. Example format:
 

--- a/src/gabriel/prompts/faceless_prompt.jinja2
+++ b/src/gabriel/prompts/faceless_prompt.jinja2
@@ -24,6 +24,11 @@ Follow these additional de-identification guidelines carefully:
 The guidelines should be followed strictly, and you should focus on thorough compliance with them. They take precedence over the default instructions.
 {% endif %}
 
+{% if additional_guidelines %}
+In addition, please take the following into account:
+{{ additional_guidelines }}
+{% endif %}
+
 For each entity, output an object with two fields:
 - "real forms": list of verbatim strings exactly as they appear in the text across all processed chunks
 - "casted form": your chosen anonymized substitute, ideally matching the original's style (e.g., similar cultural background for names, similar city for hometown). Choose a conceptually close substitute that conveys the essence of the original entity without revealing the original identity
@@ -70,6 +75,11 @@ If there is no existing mapping provided above, start a new one from scratch.
 Follow these additional de-identification guidelines carefully:
 {{ guidelines }}
 The guidelines should be followed strictly, and you should focus on thorough compliance with them.
+{% endif %}
+
+{% if additional_guidelines %}
+In addition, please take the following into account:
+{{ additional_guidelines }}
 {% endif %}
 
 Return the full mapping dictionary as JSON, retaining all existing entries and adding only. Do not include any narrative or explanation outside the JSON object.

--- a/src/gabriel/prompts/generic_classification_prompt.jinja2
+++ b/src/gabriel/prompts/generic_classification_prompt.jinja2
@@ -17,6 +17,11 @@ The possible classes are {{possible_classes}}.
 
 It is essential, for each entity, you choose one and only one class. Always choose one, never multiple. If more than one fit, choose the best one, airing on the side of choosing the tech related category. All entities irrelevant to tech should go into the 'other' category, as described precisely above. DO NOT create new classes or change the names of the classes in ANY way. Use ONLY these class choices with no modifications.
 
+{% if additional_guidelines %}
+In addition, please take the following into account:
+{{ additional_guidelines }}
+{% endif %}
+
 Your output should be in JSON format, as follows, substituting 'entity_n' for the respective entity name and <insert correct class for entity_n here> with its corresponding singular class choice:
 
 {{output_format}}

--- a/src/gabriel/prompts/generic_elo_prompt.jinja2
+++ b/src/gabriel/prompts/generic_elo_prompt.jinja2
@@ -4,6 +4,11 @@ You will be shown two passages labelled *passage circle* and *passage square*. F
 {{ instructions }}
 {% endif %}
 
+{% if additional_guidelines %}
+In addition, please take the following into account:
+{{ additional_guidelines }}
+{% endif %}
+
 **Passage circle**
 BEGIN CIRCLE
 {{ text_circle }}

--- a/src/gabriel/prompts/prompt_paraphraser_prompt.jinja2
+++ b/src/gabriel/prompts/prompt_paraphraser_prompt.jinja2
@@ -14,4 +14,9 @@ Below is the baseline prompt:
 {{ baseline_prompt }}
 """
 
+{% if additional_guidelines %}
+In addition, please take the following into account:
+{{ additional_guidelines }}
+{% endif %}
+
 Return only the new paraphrased prompt text and nothing else.

--- a/src/gabriel/prompts/ratings_prompt.jinja2
+++ b/src/gabriel/prompts/ratings_prompt.jinja2
@@ -22,8 +22,13 @@ BEGINNING OF PASSAGE. NOTHING BEFORE THIS IS PART OF PASSAGE.
 
 END OF PASSAGE. NOTHING AFTER THIS IS PART OF PASSAGE.
 
-On a scale of 0‑100, rate how much the {{ object_category }} passage manifests the
+On a scale of {{ rating_scale }}, rate how much the {{ object_category }} passage manifests the
 {{ attribute_category }} attributes of {{ attribute_list }}.
+
+{% if additional_guidelines %}
+In addition, please take the following into account:
+{{ additional_guidelines }}
+{% endif %}
 
 ---
 
@@ -31,8 +36,8 @@ On a scale of 0‑100, rate how much the {{ object_category }} passage manifests
 Return **only** the JSON object below (no markdown, no code fences, no commentary).
 
 {
-  "<insert attribute 1>": <insert integer rating for how much attribute 1 is manifested in the passage (0-100)>,
-  "<insert attribute 2>": <insert integer rating for how much attribute 2 is manifested in the passage (0-100)>,
+  "<insert attribute 1>": <insert integer rating for how much attribute 1 is manifested in the passage ({{ rating_scale }})>,
+  "<insert attribute 2>": <insert integer rating for how much attribute 2 is manifested in the passage ({{ rating_scale }})>,
   ...,
-  "<insert attribute n>": <insert integer rating for how much attribute n is manifested in the passage (0-100)>,
+  "<insert attribute n>": <insert integer rating for how much attribute n is manifested in the passage ({{ rating_scale }})>,
 }

--- a/src/gabriel/tasks/basic_classifier.py
+++ b/src/gabriel/tasks/basic_classifier.py
@@ -22,6 +22,7 @@ class BasicClassifierConfig:
     model: str = "o4-mini"
     n_parallels: int = 400
     additional_instructions: str = ""
+    additional_guidelines: str = ""
     use_dummy: bool = False
     timeout: float = 60.0
 
@@ -78,6 +79,7 @@ class BasicClassifier:
                     text=txt,
                     labels=self.cfg.labels,
                     additional_instructions=self.cfg.additional_instructions,
+                    additional_guidelines=self.cfg.additional_guidelines,
                 )
             )
             ids.append(sha8)

--- a/src/gabriel/tasks/county_counter.py
+++ b/src/gabriel/tasks/county_counter.py
@@ -33,6 +33,8 @@ class CountyCounter:
         use_dummy: bool = False,
         additional_instructions: str = "",
         elo_instructions: str = "",
+        additional_guidelines: str = "",
+        elo_guidelines: str = "",
         z_score_choropleth: bool = True,
         elo_attributes: dict | None = None,
     ) -> None:
@@ -47,6 +49,8 @@ class CountyCounter:
         self.use_dummy = use_dummy
         self.additional_instructions = additional_instructions
         self.elo_instructions = elo_instructions
+        self.additional_guidelines = additional_guidelines
+        self.elo_guidelines = elo_guidelines
         self.reasoning_effort = reasoning_effort
         self.search_context_size = search_context_size
         self.z_score_choropleth = z_score_choropleth
@@ -62,6 +66,7 @@ class CountyCounter:
             n_parallels=self.n_parallels,
             use_dummy=self.use_dummy,
             additional_instructions=self.additional_instructions,
+            additional_guidelines=self.additional_guidelines,
             reasoning_effort=self.reasoning_effort,
             search_context_size=self.search_context_size,
             print_example_prompt=True,
@@ -83,18 +88,19 @@ class CountyCounter:
                 attributes = self.elo_attributes
             else:
                 attributes = [topic]
-            cfg = EloConfig(
-                attributes=attributes,
-                n_rounds=self.n_elo_rounds,
-                n_parallels=self.n_parallels,
-                model=self.model_elo,
-                save_dir=self.save_path,
-                run_name=f"elo_{topic}",
-                use_dummy=self.use_dummy,
-                instructions=self.elo_instructions,
-                print_example_prompt=False,
-                timeout=self.elo_timeout,
-            )
+                cfg = EloConfig(
+                    attributes=attributes,
+                    n_rounds=self.n_elo_rounds,
+                    n_parallels=self.n_parallels,
+                    model=self.model_elo,
+                    save_dir=self.save_path,
+                    run_name=f"elo_{topic}",
+                    use_dummy=self.use_dummy,
+                    instructions=self.elo_instructions,
+                    additional_guidelines=self.elo_guidelines,
+                    print_example_prompt=False,
+                    timeout=self.elo_timeout,
+                )
             rater = EloRater(self.tele, cfg)
             elo_df = await rater.run(df_topic, text_col="text", id_col="identifier")
             elo_df["identifier"] = elo_df["identifier"].astype(str)

--- a/src/gabriel/tasks/deidentification.py
+++ b/src/gabriel/tasks/deidentification.py
@@ -23,6 +23,7 @@ class DeidentifyConfig:
     timeout: float = 60.0
     max_words_per_call: int = 7500
     guidelines: str = ""
+    additional_guidelines: str = ""
 
 
 class Deidentifier:
@@ -98,6 +99,7 @@ class Deidentifier:
                             text=segs[rnd],
                             current_map=json.dumps(group_to_map[gid], ensure_ascii=False),
                             guidelines=self.cfg.guidelines,
+                            additional_guidelines=self.cfg.additional_guidelines,
                         )
                     )
                     identifiers.append(f"{gid}_seg_{rnd}")

--- a/src/gabriel/tasks/elo.py
+++ b/src/gabriel/tasks/elo.py
@@ -46,6 +46,7 @@ class EloConfig:
     timeout: float = 45.0
     print_example_prompt: bool = True
     instructions: str = ""
+    additional_guidelines: str = ""
     save_dir: str = os.path.expanduser("~/Documents/runs")
     run_name: str = f"elo_{datetime.now():%Y%m%d_%H%M%S}"
     seed: Optional[int] = None
@@ -426,6 +427,7 @@ class EloRater:
                             text_square=t_b,
                             attributes=attr_def_map,
                             instructions=self.cfg.instructions,
+                            additional_guidelines=self.cfg.additional_guidelines,
                         )
                     )
                     ids.append(f"{rnd}|{batch_idx}|{pair_idx}|{id_a}|{id_b}")

--- a/src/gabriel/tasks/ratings.py
+++ b/src/gabriel/tasks/ratings.py
@@ -1,6 +1,6 @@
 # src/gabriel/tasks/ratings.py
 # ════════════════════════════════════════════════════════════════════
-# Robust 0-100 passage-rating task with optional debug logging.
+# Robust passage-rating task with optional debug logging.
 # ════════════════════════════════════════════════════════════════════
 from __future__ import annotations
 
@@ -29,6 +29,8 @@ class RatingsConfig:
     save_path: str = "ratings.csv"
     use_dummy: bool = False
     timeout: float = 60.0
+    rating_scale: str = "0-100"
+    additional_guidelines: str = ""
 
 
 # ────────────────────────────
@@ -158,6 +160,8 @@ class Ratings:
                     passage=passage,
                     object_category="text",
                     attribute_category="attributes",
+                    rating_scale=self.cfg.rating_scale,
+                    additional_guidelines=self.cfg.additional_guidelines,
                 )
             )
             ids.append(sha8)

--- a/src/gabriel/tasks/regional.py
+++ b/src/gabriel/tasks/regional.py
@@ -21,6 +21,7 @@ class RegionalConfig:
     run_name: str | None = None
     use_dummy: bool = False
     additional_instructions: str = ""
+    additional_guidelines: str = ""
     reasoning_effort: str = "medium"
     search_context_size: str = "medium"
     print_example_prompt: bool = True
@@ -57,6 +58,7 @@ class Regional:
                         region=region,
                         topic=topic,
                         additional_instructions=self.cfg.additional_instructions,
+                        additional_guidelines=self.cfg.additional_guidelines,
                     )
                 )
                 ids.append(f"{region}|{topic}")

--- a/src/gabriel/utils/teleprompter.py
+++ b/src/gabriel/utils/teleprompter.py
@@ -21,6 +21,7 @@ class Teleprompter:
         text_square: str,
         attributes: Union[Dict[str, str], List[str]],
         instructions: str = "",
+        additional_guidelines: str = "",
     ) -> str:
         """Render the generic elo comparison prompt."""
         if isinstance(attributes, list):
@@ -31,4 +32,5 @@ class Teleprompter:
             text_square=text_square,
             attributes=attributes,
             instructions=instructions,
+            additional_guidelines=additional_guidelines,
         )


### PR DESCRIPTION
## Summary
- allow specifying rating_scale and additional_guidelines in RatingsConfig
- pass additional_guidelines to all prompt templates
- support custom rating scale in ratings prompt
- update teleprompter and tasks to include additional_guidelines
- extend county_counter, deidentification and other configs
- update legacy and modern prompt templates accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687871edf0f88332913e491c9b2e8fc8