### PR TITLE
Add shared JSON parser and refactor tasks

### DIFF
--- a/src/gabriel/tasks/elo.py
+++ b/src/gabriel/tasks/elo.py
@@ -1,9 +1,6 @@
 """Advanced Elo rating implementation."""
 from __future__ import annotations
 
-import ast
-import json
-
 import os
 import random
 from dataclasses import dataclass
@@ -15,6 +12,7 @@ import pandas as pd
 
 from ..utils.teleprompter import Teleprompter
 from ..utils.openai_utils import get_all_responses
+from ..utils import safe_json
 
 
 @dataclass
@@ -70,30 +68,6 @@ class EloRater:
             self.history_multi[attr] = []
         self.history_multi[attr].append(ranking)
 
-    @staticmethod
-    def _safe_json(txt: Any) -> dict:
-        try:
-            if isinstance(txt, dict):
-                return txt
-            if isinstance(txt, list):
-                if txt and isinstance(txt[0], dict):
-                    return txt[0]
-                if txt and isinstance(txt[0], str):
-                    txt = txt[0]
-            cleaned = str(txt).strip()
-            if (cleaned.startswith('"') and cleaned.endswith('"')) or (
-                cleaned.startswith("'") and cleaned.endswith("'")
-            ):
-                cleaned = cleaned[1:-1]
-            try:
-                return json.loads(cleaned)
-            except Exception:
-                try:
-                    return ast.literal_eval(cleaned)
-                except Exception:
-                    return {}
-        except Exception:
-            return {}
 
     def _fit_bt(
         self,
@@ -450,9 +424,9 @@ class EloRater:
                 except Exception:
                     continue
 
-                safe = self._safe_json(resp)
+                safe = safe_json(resp)
                 if isinstance(resp, list) and not safe:
-                    safe = self._safe_json(resp[0])
+                    safe = safe_json(resp[0])
                 if not isinstance(safe, dict) or not safe:
                     continue
 

--- a/src/gabriel/utils/__init__.py
+++ b/src/gabriel/utils/__init__.py
@@ -5,6 +5,7 @@ from .logging import get_logger
 from .teleprompter import Teleprompter
 from .maps import create_county_choropleth
 from .prompt_paraphraser import PromptParaphraser, PromptParaphraserConfig
+from .parsing import safe_json
 
 __all__ = [
     "get_response",
@@ -14,4 +15,5 @@ __all__ = [
     "create_county_choropleth",
     "PromptParaphraser",
     "PromptParaphraserConfig",
+    "safe_json",
 ]

--- a/src/gabriel/utils/openai_utils.py
+++ b/src/gabriel/utils/openai_utils.py
@@ -11,6 +11,7 @@ import pandas as pd
 from aiolimiter import AsyncLimiter
 from tqdm import tqdm
 import openai
+from .parsing import safe_json
 
 # single connection pool per process, created lazily
 client_async: Optional[openai.AsyncOpenAI] = None
@@ -138,15 +139,8 @@ def _de(x: Any) -> Any:
     """Deserialize JSON strings back to Python objects."""
     if pd.isna(x):
         return None
-    try:
-        return json.loads(x)
-    except Exception:
-        try:
-            import ast
-
-            return ast.literal_eval(x)
-        except Exception:
-            return None
+    parsed = safe_json(x)
+    return parsed if parsed else None
 
 
 async def get_all_responses(

--- a/src/gabriel/utils/parsing.py
+++ b/src/gabriel/utils/parsing.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import ast
+import json
+import re
+from typing import Any
+
+_JSON_FENCE_RE = re.compile(r"```(?:json)?\s*(.*?)\s*```", re.S)
+
+
+def safe_json(txt: Any) -> dict | list:
+    """Best-effort JSON parser returning ``{}`` on failure."""
+    if isinstance(txt, (dict, list)):
+        return txt
+
+    if isinstance(txt, list) and txt:
+        return safe_json(txt[0])
+
+    if isinstance(txt, (bytes, bytearray)):
+        txt = txt.decode(errors="ignore")
+
+    if txt is None:
+        return {}
+
+    cleaned = str(txt).strip()
+
+    if (cleaned.startswith('"') and cleaned.endswith('"')) or (
+        cleaned.startswith("'") and cleaned.endswith("'")
+    ):
+        cleaned = cleaned[1:-1].strip()
+
+    m = _JSON_FENCE_RE.search(cleaned)
+    if m:
+        cleaned = m.group(1).strip()
+
+    try:
+        return json.loads(cleaned)
+    except Exception:
+        pass
+
+    try:
+        return ast.literal_eval(cleaned)
+    except Exception:
+        pass
+
+    try:
+        brace = re.search(r"\{[\s\S]*\}", cleaned)
+        if brace:
+            return json.loads(brace.group(0))
+    except Exception:
+        pass
+
+    return {}


### PR DESCRIPTION
## Summary
- introduce `safe_json` in utils for robust JSON parsing
- expose `safe_json` from the utils package
- use `safe_json` across tasks and openai utilities
- clean imports accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687875451b388332abfaffd25e6f29a7