### PR TITLE
Flatten ratings output

### DIFF
--- a/src/gabriel/tasks/ratings.py
+++ b/src/gabriel/tasks/ratings.py
@@ -87,7 +87,7 @@ class Ratings:
     # Main entry point
     # -----------------------------------------------------------------
     async def run(self, texts: List[str], *, debug: bool = False) -> pd.DataFrame:
-        """Return DataFrame with a 'ratings' column (dict per row)."""
+        """Return DataFrame with one column per attribute rating."""
 
         prompts: List[str] = []
         ids: List[str] = []
@@ -140,7 +140,10 @@ class Ratings:
         ratings_list: List[Dict[str, Optional[float]]] = []
         for passage in texts:
             sha8 = hashlib.sha1(passage.encode()).hexdigest()[:8]
-            ratings_list.append(id_to_ratings.get(sha8, {}))
+            parsed = id_to_ratings.get(sha8, {})
+            ratings_list.append({attr: parsed.get(attr) for attr in self.cfg.attributes})
 
-        return pd.DataFrame({"text": texts, "ratings": ratings_list})
+        ratings_df = pd.DataFrame(ratings_list)
+        ratings_df.insert(0, "text", texts)
+        return ratings_df
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -44,6 +44,7 @@ def test_ratings_dummy(tmp_path):
     task = Ratings(cfg)
     df = asyncio.run(task.run(["hello"]))
     assert not df.empty
+    assert "helpfulness" in df.columns
 
 
 def test_deidentifier_dummy(tmp_path):


### PR DESCRIPTION
## Summary
- flatten Ratings output so each attribute is its own column
- check for attribute column in unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d693845008332a9c8aa27ab180257