### PR TITLE
Add reset_files option to tasks

### DIFF
--- a/src/gabriel/tasks/county_counter.py
+++ b/src/gabriel/tasks/county_counter.py
@@ -102,7 +102,9 @@ class CountyCounter:
                     timeout=self.elo_timeout,
                 )
             rater = EloRater(self.tele, cfg)
-            elo_df = await rater.run(df_topic, text_col="text", id_col="identifier")
+            elo_df = await rater.run(
+                df_topic, text_col="text", id_col="identifier", reset_files=reset_files
+            )
             elo_df["identifier"] = elo_df["identifier"].astype(str)
             results["region"] = results["region"].astype(str)
             if self.elo_attributes:

--- a/src/gabriel/tasks/elo.py
+++ b/src/gabriel/tasks/elo.py
@@ -347,7 +347,9 @@ class EloRater:
             )
         return self._pairs_adjacent(item_ids, texts_by_id, current_ratings, mpr)
 
-    async def run(self, df: pd.DataFrame, text_col: str, id_col: str) -> pd.DataFrame:
+    async def run(
+        self, df: pd.DataFrame, text_col: str, id_col: str, *, reset_files: bool = False
+    ) -> pd.DataFrame:
         final_path = os.path.join(self.save_path, self.cfg.final_filename)
         if os.path.exists(final_path):
             return pd.read_csv(final_path)
@@ -412,7 +414,7 @@ class EloRater:
                 model=self.cfg.model,
                 json_mode=True,
                 save_path=os.path.join(self.save_path, f"round{rnd}.csv"),
-                reset_files=False,
+                reset_files=reset_files,
                 use_dummy=self.cfg.use_dummy,
                 timeout=self.cfg.timeout,
                 print_example_prompt=self.cfg.print_example_prompt,

--- a/src/gabriel/tasks/ratings.py
+++ b/src/gabriel/tasks/ratings.py
@@ -86,7 +86,9 @@ class Ratings:
     # -----------------------------------------------------------------
     # Main entry point
     # -----------------------------------------------------------------
-    async def run(self, texts: List[str], *, debug: bool = False) -> pd.DataFrame:
+    async def run(
+        self, texts: List[str], *, debug: bool = False, reset_files: bool = False
+    ) -> pd.DataFrame:
         """Return DataFrame with one column per attribute rating."""
 
         prompts: List[str] = []
@@ -121,6 +123,7 @@ class Ratings:
             use_dummy=self.cfg.use_dummy,
             timeout=self.cfg.timeout,
             json_mode=True,
+            reset_files=reset_files,
         )
 
         # optional debug dump

--- a/src/gabriel/tasks/recursive_elo.py
+++ b/src/gabriel/tasks/recursive_elo.py
@@ -189,7 +189,9 @@ class RecursiveEloRater:
 
     # ------------------------------ Public ------------------------------
 
-    async def run(self, df: pd.DataFrame, text_col: str, id_col: str) -> pd.DataFrame:
+    async def run(
+        self, df: pd.DataFrame, text_col: str, id_col: str, *, reset_files: bool = False
+    ) -> pd.DataFrame:
         """
         Execute recursive Elo rating.
 
@@ -254,7 +256,12 @@ class RecursiveEloRater:
 
             # Run EloRater
             elo = EloRater(self.tele, stage_cfg)
-            stage_df_out = await elo.run(stage_df_in, text_col="text", id_col="identifier")
+            stage_df_out = await elo.run(
+                stage_df_in,
+                text_col="text",
+                id_col="identifier",
+                reset_files=reset_files,
+            )
 
             # Record stage columns if desired
             if self.cfg.keep_stage_columns:


### PR DESCRIPTION
## Summary
- allow `reset_files` in Ratings task to restart saved CSVs
- thread through EloRater and RecursiveEloRater
- pass reset_files from CountyCounter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e7ee8d2f08332bba764159445094e