### PR TITLE
Refactor classifier and ratings for DataFrame input

### DIFF
--- a/src/gabriel/utils/prompt_paraphraser.py
+++ b/src/gabriel/utils/prompt_paraphraser.py
@@ -69,6 +69,9 @@ class PromptParaphraser:
         for idx, text in enumerate(variants, start=1):
             variant_template = PromptTemplate(text)
             cfg_variant = copy.deepcopy(task_cfg)
+            if hasattr(cfg_variant, "file_name"):
+                base, ext = os.path.splitext(cfg_variant.file_name)
+                cfg_variant.file_name = f"{base}_p{idx}{ext}"
             if hasattr(cfg_variant, "save_path"):
                 base, ext = os.path.splitext(cfg_variant.save_path)
                 cfg_variant.save_path = f"{base}_p{idx}{ext}"

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -40,9 +40,10 @@ def test_get_all_responses_dummy(tmp_path):
 
 
 def test_ratings_dummy(tmp_path):
-    cfg = RatingsConfig(attributes={"helpfulness": ""}, save_path=str(tmp_path/"ratings.csv"), use_dummy=True)
+    cfg = RatingsConfig(attributes={"helpfulness": ""}, save_dir=str(tmp_path), file_name="ratings.csv", use_dummy=True)
     task = Ratings(cfg)
-    df = asyncio.run(task.run(["hello"]))
+    data = pd.DataFrame({"text": ["hello"]})
+    df = asyncio.run(task.run(data, text_column="text"))
     assert not df.empty
     assert "helpfulness" in df.columns
 
@@ -89,11 +90,13 @@ def test_county_counter_dummy(tmp_path):
 def test_prompt_paraphraser_ratings(tmp_path):
     cfg = RatingsConfig(
         attributes={"quality": ""},
-        save_path=str(tmp_path / "rat.csv"),
+        save_dir=str(tmp_path),
+        file_name="rat.csv",
         use_dummy=True,
     )
     parap_cfg = PromptParaphraserConfig(n_variants=2, save_dir=str(tmp_path / "para"), use_dummy=True)
     paraphraser = PromptParaphraser(parap_cfg)
-    df = asyncio.run(paraphraser.run(Ratings, cfg, ["hello"]))
+    data = pd.DataFrame({"txt": ["hello"]})
+    df = asyncio.run(paraphraser.run(Ratings, cfg, data, text_column="txt"))
     assert set(df.prompt_variant) == {"baseline", "variant_1", "variant_2"}
 


### PR DESCRIPTION
## Summary
- update `BasicClassifier` and `Ratings` configs to use `save_dir`/`file_name`
- adjust `run` methods to accept DataFrame input with `text_column`
- support file name variants in `PromptParaphraser`
- update unit tests to new interfaces

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887b21f350c83329edd30e21bb91b90