### PR TITLE
Add stress test notebook

### DIFF
--- a/examples/library_stress_test.ipynb
+++ b/examples/library_stress_test.ipynb
@@ -1,0 +1,324 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "39415dad",
+   "metadata": {},
+   "source": [
+    "# GABRIEL Library Stress Test\n",
+    "\n",
+    "This notebook exercises various API calls and pipelines in dummy mode to verify the library works as expected. All OpenAI calls use the built-in dummy responses, so it can run offline and be re-run safely."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1e35f145",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "import os, sys, shutil, asyncio, pandas as pd\n",
+    "sys.path.insert(0, os.path.abspath('../src'))\n",
+    "from gabriel.utils import openai_utils\n",
+    "from gabriel.tasks import (\n",
+    "    Ratings, RatingsConfig,\n",
+    "    BasicClassifier, BasicClassifierConfig,\n",
+    "    Deidentifier, DeidentifyConfig,\n",
+    "    Regional, RegionalConfig,\n",
+    "    CountyCounter,\n",
+    "    EloRater, EloConfig,\n",
+    "    RecursiveEloConfig, RecursiveEloRater,\n",
+    ")\n",
+    "from gabriel.utils import Teleprompter, PromptParaphraser, PromptParaphraserConfig\n",
+    "\n",
+    "out_dir = 'stress_test_outputs'\n",
+    "if os.path.exists(out_dir):\n",
+    "    shutil.rmtree(out_dir)\n",
+    "os.makedirs(out_dir, exist_ok=True)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ff850e82",
+   "metadata": {},
+   "source": [
+    "## Basic `get_all_responses`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a5e0fea7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "prompts = ['Hello world', 'How are you?']\n",
+    "df = asyncio.run(openai_utils.get_all_responses(prompts=prompts, identifiers=['p1','p2'], use_dummy=True, save_path=os.path.join(out_dir,'basic.csv')))\n",
+    "df\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "16edcbda",
+   "metadata": {},
+   "source": [
+    "## JSON mode"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7ffb321b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "json_prompts = ['{\"a\":1}', '{\"b\":2}']\n",
+    "schema = {\"type\": \"object\"}\n",
+    "json_df = asyncio.run(openai_utils.get_all_responses(prompts=json_prompts, json_mode=True, expected_schema=schema, use_dummy=True, save_path=os.path.join(out_dir,'json.csv')))\n",
+    "json_df\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7e706606",
+   "metadata": {},
+   "source": [
+    "## Web search tool usage"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8d025ee6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "search_prompts = ['What is the capital of France?']\n",
+    "web_df = asyncio.run(openai_utils.get_all_responses(prompts=search_prompts, identifiers=['search'], use_web_search=True, use_dummy=True, save_path=os.path.join(out_dir,'web.csv')))\n",
+    "web_df\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9e5299f5",
+   "metadata": {},
+   "source": [
+    "## Resume from existing results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d05872a6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "resume_prompts = ['A1','A2','A3']\n",
+    "# First run with only two prompts\n",
+    "_ = asyncio.run(openai_utils.get_all_responses(prompts=resume_prompts[:2], identifiers=['r1','r2'], use_dummy=True, save_path=os.path.join(out_dir,'resume.csv')))\n",
+    "# Second run with all prompts (should only process missing one)\n",
+    "resume_df = asyncio.run(openai_utils.get_all_responses(prompts=resume_prompts, identifiers=['r1','r2','r3'], use_dummy=True, save_path=os.path.join(out_dir,'resume.csv')))\n",
+    "resume_df\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "19995ae0",
+   "metadata": {},
+   "source": [
+    "## Ratings pipeline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5a2a3878",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "data = pd.DataFrame({'text': ['This product is great.', 'Terrible experience.']})\n",
+    "ratings_cfg = RatingsConfig(attributes={'quality':'Overall quality'}, save_dir=os.path.join(out_dir,'ratings'), use_dummy=True)\n",
+    "ratings_res = asyncio.run(Ratings(ratings_cfg).run(data, text_column='text'))\n",
+    "ratings_res\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3678419d",
+   "metadata": {},
+   "source": [
+    "## BasicClassifier pipeline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bcc292dd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "clf_data = pd.DataFrame({'txt': ['I love pizza', 'I hate spinach']})\n",
+    "clf_cfg = BasicClassifierConfig(labels={'positive':'Is the sentiment positive?'}, save_dir=os.path.join(out_dir,'classifier'), use_dummy=True)\n",
+    "clf_res = asyncio.run(BasicClassifier(clf_cfg).run(clf_data, text_column='txt'))\n",
+    "clf_res\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a77d3574",
+   "metadata": {},
+   "source": [
+    "## Deidentifier pipeline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "59de6183",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "deid_data = pd.DataFrame({'text':['John Doe went to New York.']})\n",
+    "deid_cfg = DeidentifyConfig(save_path=os.path.join(out_dir,'deid.csv'), use_dummy=True)\n",
+    "deid_res = asyncio.run(Deidentifier(deid_cfg).run(deid_data, text_column='text'))\n",
+    "deid_res\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "060f2a56",
+   "metadata": {},
+   "source": [
+    "## Regional analysis pipeline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8a9227cc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "reg_data = pd.DataFrame({'county':['A','B']})\n",
+    "reg_cfg = RegionalConfig(save_dir=os.path.join(out_dir,'regional'), use_dummy=True)\n",
+    "regional_task = Regional(reg_data, 'county', topics=['economy'], cfg=reg_cfg)\n",
+    "regional_res = asyncio.run(regional_task.run())\n",
+    "regional_res\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "827c9172",
+   "metadata": {},
+   "source": [
+    "## CountyCounter pipeline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "109dc797",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "county_data = pd.DataFrame({'county':['A','B'], 'fips':['00001','00002']})\n",
+    "cc = CountyCounter(county_data, county_col='county', topics=['econ'], fips_col='fips', save_dir=os.path.join(out_dir,'county'), use_dummy=True, n_elo_rounds=1)\n",
+    "county_res = asyncio.run(cc.run())\n",
+    "county_res\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "298b8aff",
+   "metadata": {},
+   "source": [
+    "## EloRater pipeline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "66d35971",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "elo_data = pd.DataFrame({'identifier':['x','y'], 'text':['Text X','Text Y']})\n",
+    "tele = Teleprompter()\n",
+    "elo_cfg = EloConfig(attributes={'clarity':''}, n_rounds=1, save_dir=os.path.join(out_dir,'elo'), use_dummy=True)\n",
+    "elo_task = EloRater(tele, elo_cfg)\n",
+    "elo_res = asyncio.run(elo_task.run(elo_data, text_col='text', id_col='identifier'))\n",
+    "elo_res\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "99a8a7fd",
+   "metadata": {},
+   "source": [
+    "## RecursiveEloRater pipeline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9886a303",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "rec_data = pd.DataFrame({'identifier':['a','b','c'], 'text':['Alpha','Bravo','Charlie']})\n",
+    "base_cfg = EloConfig(attributes={'score':''}, n_rounds=1, save_dir=os.path.join(out_dir,'rec'), use_dummy=True)\n",
+    "rec_cfg = RecursiveEloConfig(base_cfg=base_cfg, min_remaining=2)\n",
+    "rec_task = RecursiveEloRater(tele, rec_cfg)\n",
+    "rec_res = asyncio.run(rec_task.run(rec_data, text_col='text', id_col='identifier'))\n",
+    "rec_res\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "da1a8d05",
+   "metadata": {},
+   "source": [
+    "## PromptParaphraser"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6fa9cb5d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "parap_cfg = PromptParaphraserConfig(n_variants=2, save_dir=os.path.join(out_dir,'parap'), use_dummy=True)\n",
+    "parap = PromptParaphraser(parap_cfg)\n",
+    "parap_res = asyncio.run(parap.run(Ratings, ratings_cfg, data, text_column='text'))\n",
+    "parap_res\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add a new example notebook `library_stress_test.ipynb`
- notebook exercises `get_all_responses` and all major pipelines in dummy mode
- includes tests for web search, json responses and resuming from a partial file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887b5df8fa883329e2a13913863bd7e