### PR TITLE
Improve JSON parsing with LLM fallback

### DIFF
--- a/src/gabriel/tasks/basic_classifier.py
+++ b/src/gabriel/tasks/basic_classifier.py
@@ -96,7 +96,7 @@ class BasicClassifier:
             out[lab] = None if not m else m.group(1).lower() == "true"
         return out
 
-    def _parse(self, resp: Any) -> Dict[str, Optional[bool]]:
+    async def _parse(self, resp: Any) -> Dict[str, Optional[bool]]:
         # unwrap common response containers (list-of-one, bytes, fenced blocks)
         if isinstance(resp, list) and len(resp) == 1:
             resp = resp[0]
@@ -107,7 +107,7 @@ class BasicClassifier:
             if m:
                 resp = m.group(1).strip()
 
-        data = safe_json(resp)
+        data = await safe_json(resp, use_dummy=self.cfg.use_dummy)
         if isinstance(data, dict):
             norm = {
                 k.strip().lower(): (
@@ -167,7 +167,7 @@ class BasicClassifier:
             if ident not in id_to_rows:
                 orphans += 1
                 continue
-            parsed = self._parse(raw)
+            parsed = await self._parse(raw)
             for row in id_to_rows[ident]:
                 parsed_master[row] = parsed
 

--- a/src/gabriel/tasks/deidentification.py
+++ b/src/gabriel/tasks/deidentification.py
@@ -108,7 +108,7 @@ class Deidentifier:
             for ident, resp in zip(batch_df["Identifier"], batch_df["Response"]):
                 gid = ident.split("_seg_")[0]
                 main = resp[0] if isinstance(resp, list) and resp else ""
-                parsed = safe_json(main)
+                parsed = await safe_json(main, use_dummy=self.cfg.use_dummy)
                 if parsed:
                     group_to_map[gid] = parsed
 

--- a/src/gabriel/tasks/elo.py
+++ b/src/gabriel/tasks/elo.py
@@ -379,21 +379,21 @@ class EloRater:
                     continue
 
                 # robust dict coercion
-                def _coerce_dict(raw: Any) -> Dict[str, Any]:
-                    obj = safe_json(raw)
+                async def _coerce_dict(raw: Any) -> Dict[str, Any]:
+                    obj = await safe_json(raw, use_dummy=self.cfg.use_dummy)
                     if isinstance(obj, dict):
                         return obj
                     if isinstance(obj, str):
-                        obj2 = safe_json(obj)
+                        obj2 = await safe_json(obj, use_dummy=self.cfg.use_dummy)
                         if isinstance(obj2, dict):
                             return obj2
                     if isinstance(obj, list) and obj:
-                        inner = safe_json(obj[0])
+                        inner = await safe_json(obj[0], use_dummy=self.cfg.use_dummy)
                         if isinstance(inner, dict):
                             return inner
                     return {}
 
-                safe_obj = _coerce_dict(resp)
+                safe_obj = await _coerce_dict(resp)
                 if not safe_obj:
                     continue
 

--- a/src/gabriel/tasks/ratings.py
+++ b/src/gabriel/tasks/ratings.py
@@ -50,8 +50,8 @@ class Ratings:
     # -----------------------------------------------------------------
     # Parse raw LLM output into {attribute: float}
     # -----------------------------------------------------------------
-    def _parse(self, raw: Any) -> Dict[str, Optional[float]]:
-        obj = safe_json(raw)
+    async def _parse(self, raw: Any) -> Dict[str, Optional[float]]:
+        obj = await safe_json(raw, use_dummy=self.cfg.use_dummy)
         out: Dict[str, Optional[float]] = {}
 
         # shape A: {"data":[{"attribute":"clarity","rating":88}, …]}
@@ -151,7 +151,7 @@ class Ratings:
         id_to_ratings: Dict[str, Dict[str, Optional[float]]] = {}
         for ident, raw in zip(df_resp.Identifier, df_resp.Response):
             main = raw[0] if isinstance(raw, list) and raw else raw
-            id_to_ratings[ident] = self._parse(main)
+            id_to_ratings[ident] = await self._parse(main)
 
         ratings_list: List[Dict[str, Optional[float]]] = []
         for passage in texts:

--- a/src/gabriel/utils/__init__.py
+++ b/src/gabriel/utils/__init__.py
@@ -5,7 +5,7 @@ from .logging import get_logger
 from .teleprompter import Teleprompter
 from .maps import create_county_choropleth
 from .prompt_paraphraser import PromptParaphraser, PromptParaphraserConfig
-from .parsing import safe_json
+from .parsing import safe_json, parse_json
 
 __all__ = [
     "get_response",
@@ -16,4 +16,5 @@ __all__ = [
     "PromptParaphraser",
     "PromptParaphraserConfig",
     "safe_json",
+    "parse_json",
 ]

--- a/src/gabriel/utils/parsing.py
+++ b/src/gabriel/utils/parsing.py
@@ -2,19 +2,22 @@ from __future__ import annotations
 
 import ast
 import json
+import os
 import re
 from typing import Any
+
+DEFAULT_JSON_LLM_MODEL = os.getenv("JSON_LLM_MODEL", "gpt-4o-mini")
 
 _JSON_FENCE_RE = re.compile(r"```(?:json)?\s*(.*?)\s*```", re.S)
 
 
-def safe_json(txt: Any) -> dict | list:
-    """Best-effort JSON parser returning ``{}`` on failure."""
+def parse_json(txt: Any) -> dict | list:
+    """Synchronously parse JSON with multiple fallbacks."""
     if isinstance(txt, (dict, list)):
         return txt
 
     if isinstance(txt, list) and txt:
-        return safe_json(txt[0])
+        return parse_json(txt[0])
 
     if isinstance(txt, (bytes, bytearray)):
         txt = txt.decode(errors="ignore")
@@ -33,21 +36,50 @@ def safe_json(txt: Any) -> dict | list:
     if m:
         cleaned = m.group(1).strip()
 
-    try:
-        return json.loads(cleaned)
-    except Exception:
-        pass
+    for parser in (json.loads, ast.literal_eval):
+        try:
+            return parser(cleaned)
+        except Exception:
+            pass
 
-    try:
-        return ast.literal_eval(cleaned)
-    except Exception:
-        pass
-
-    try:
-        brace = re.search(r"\{[\s\S]*\}", cleaned)
-        if brace:
+    brace = re.search(r"\{[\s\S]*\}", cleaned)
+    if brace:
+        try:
             return json.loads(brace.group(0))
-    except Exception:
-        pass
+        except Exception:
+            pass
 
     return {}
+
+
+async def safe_json(
+    txt: Any,
+    *,
+    json_llm_model: str | None = None,
+    use_dummy: bool = False,
+) -> dict | list:
+    """Parse JSON, optionally reformatted by an LLM on failure."""
+    result = parse_json(txt)
+    if result:
+        return result
+
+    cleaned = str(txt).strip() if txt is not None else ""
+    if not cleaned:
+        return {}
+
+    model = json_llm_model or DEFAULT_JSON_LLM_MODEL
+    try:
+        from .openai_utils import get_response
+        fixed, _ = await get_response(
+            prompt=(
+                "Please parse the following text **without changing any "
+                "content** into valid JSON. This is a pure formatting task.\n\n"
+                + cleaned
+            ),
+            model=model,
+            json_mode=True,
+            use_dummy=use_dummy,
+        )
+        return parse_json(fixed[0])
+    except Exception:
+        return {}


### PR DESCRIPTION
## Summary
- add `parse_json` and async `safe_json` with optional LLM reformatting
- propagate dummy flag to JSON parsing calls
- skip rate limit introspection and dynamic behaviour when `use_dummy=True`
- provide fast path for dummy responses in `get_all_responses`
- update tasks to use async JSON parsing

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887c1635f5883328628feaaaa283055