### PR TITLE
Add optional image input support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,20 @@ print(ratings)
 
 Each task returns a `pandas.DataFrame` and saves raw responses to disk.  Set `use_dummy=False` and provide your OpenAI credentials via the `OPENAI_API_KEY` environment variable to perform real API calls.
 
+### Image inputs
+
+`get_response` and `get_all_responses` can optionally include images with your prompts. Pass the `images` parameter to `get_response` or a mapping `prompt_images` to `get_all_responses`, where each key is a prompt identifier and the value is a list of base64 strings. A helper `encode_image` is provided:
+
+```python
+from gabriel.utils import encode_image
+
+img_b64 = encode_image("picture.jpg")
+responses = asyncio.run(
+    get_response("Describe this", images=[img_b64], use_dummy=True)
+)
+```
+
+
 ## Tasks
 
 ### `Ratings`

--- a/src/gabriel/tasks/elo.py
+++ b/src/gabriel/tasks/elo.py
@@ -293,7 +293,15 @@ class EloRater:
         return self._pairs_adjacent(item_ids, texts_by_id, current_ratings, mpr)
 
     # ---------- main ----------
-    async def run(self, df: pd.DataFrame, text_col: str, id_col: str, *, reset_files: bool = False) -> pd.DataFrame:
+    async def run(
+        self,
+        df: pd.DataFrame,
+        text_col: str,
+        id_col: str,
+        *,
+        reset_files: bool = False,
+        **kwargs: Any,
+    ) -> pd.DataFrame:
         final_path = os.path.join(self.save_path, self.cfg.final_filename)
         if not reset_files and os.path.exists(final_path):
             return pd.read_csv(final_path)
@@ -357,6 +365,7 @@ class EloRater:
                 use_dummy=self.cfg.use_dummy,
                 timeout=self.cfg.timeout,
                 print_example_prompt=self.cfg.print_example_prompt,
+                **kwargs,
             )
 
             for ident, resp in zip(resp_df.Identifier, resp_df.Response):

--- a/src/gabriel/tasks/ratings.py
+++ b/src/gabriel/tasks/ratings.py
@@ -96,6 +96,7 @@ class Ratings:
         *,
         debug: bool = False,
         reset_files: bool = False,
+        **kwargs: Any,
     ) -> pd.DataFrame:
         """Return ``df`` with one column per attribute rating."""
 
@@ -137,6 +138,7 @@ class Ratings:
             timeout=self.cfg.timeout,
             json_mode=True,
             reset_files=reset_files,
+            **kwargs,
         )
 
         # optional debug dump

--- a/src/gabriel/utils/__init__.py
+++ b/src/gabriel/utils/__init__.py
@@ -1,6 +1,7 @@
 """Utility helpers for GABRIEL."""
 
 from .openai_utils import get_response, get_all_responses
+from .image_utils import encode_image
 from .logging import get_logger
 from .teleprompter import Teleprompter
 from .maps import create_county_choropleth
@@ -16,4 +17,5 @@ __all__ = [
     "PromptParaphraser",
     "PromptParaphraserConfig",
     "safe_json",
+    "encode_image",
 ]

--- a/src/gabriel/utils/image_utils.py
+++ b/src/gabriel/utils/image_utils.py
@@ -1,0 +1,22 @@
+import base64
+from typing import Optional
+
+
+def encode_image(image_path: str) -> Optional[str]:
+    """Return the contents of ``image_path`` as a base64 string.
+
+    Parameters
+    ----------
+    image_path: str
+        Path to the image file to encode.
+
+    Returns
+    -------
+    str or None
+        The base64-encoded contents of the file, or ``None`` if reading fails.
+    """
+    try:
+        with open(image_path, "rb") as image_file:
+            return base64.b64encode(image_file.read()).decode("utf-8")
+    except Exception:
+        return None

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -29,6 +29,13 @@ def test_get_response_dummy():
     assert responses and responses[0].startswith("DUMMY")
 
 
+def test_get_response_images_dummy():
+    responses, _ = asyncio.run(
+        openai_utils.get_response("hi", images=["abcd"], use_dummy=True)
+    )
+    assert responses and responses[0].startswith("DUMMY")
+
+
 def test_get_all_responses_dummy(tmp_path):
     df = asyncio.run(openai_utils.get_all_responses(
         prompts=["a", "b"],
@@ -37,6 +44,19 @@ def test_get_all_responses_dummy(tmp_path):
         use_dummy=True,
     ))
     assert len(df) == 2
+
+
+def test_get_all_responses_images_dummy(tmp_path):
+    df = asyncio.run(
+        openai_utils.get_all_responses(
+            prompts=["a"],
+            identifiers=["1"],
+            prompt_images={"1": ["abcd"]},
+            save_path=str(tmp_path / "img.csv"),
+            use_dummy=True,
+        )
+    )
+    assert len(df) == 1
 
 
 def test_ratings_dummy(tmp_path):


### PR DESCRIPTION
## Summary
- support optional image inputs in get_response and get_all_responses
- expose encode_image utility
- pass extra kwargs in Ratings and Elo run methods
- document image usage in README
- test dummy image behaviour

## Testing
- `pip install -e .[dev]`
- `pytest tests/test_basic.py::test_prompt_template -q`
- `pytest tests/test_basic.py::test_get_response_images_dummy -q`
- `pytest -q` *(fails: KeyboardInterrupt after several minutes)*

------
https://chatgpt.com/codex/tasks/task_e_6887b95d0cdc8332bccb587a2b8369e7