### PR TITLE
Expand stress notebook and fix imports

### DIFF
--- a/examples/library_stress_test.ipynb
+++ b/examples/library_stress_test.ipynb
@@ -39,6 +39,24 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\ntry:\n    from sklearn.datasets import fetch_20newsgroups\n    ng = fetch_20newsgroups(subset='train', categories=['sci.space'], remove=('headers','footers','quotes'), download_if_missing=False)\n    sample_texts = ng.data[:3]\nexcept Exception:\n    sample_texts = ['Space exploration','Galaxy news','Astronomy facts']\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\nng_df = await openai_utils.get_all_responses(prompts=sample_texts, identifiers=['ng1','ng2','ng3'], use_dummy=True, save_path=os.path.join(out_dir,'ng.csv'))\nng_df\n"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "ff850e82",
    "metadata": {},
@@ -53,10 +71,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n",
-    "prompts = ['Hello world', 'How are you?']\n",
-    "df = asyncio.run(openai_utils.get_all_responses(prompts=prompts, identifiers=['p1','p2'], use_dummy=True, save_path=os.path.join(out_dir,'basic.csv')))\n",
-    "df\n"
+    "\nprompts = ['Hello world', 'How are you?']\ndf = await openai_utils.get_all_responses(prompts=prompts, identifiers=['p1','p2'], use_dummy=True, save_path=os.path.join(out_dir,'basic.csv'))\ndf\n"
    ]
   },
   {
@@ -74,11 +89,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n",
-    "json_prompts = ['{\"a\":1}', '{\"b\":2}']\n",
-    "schema = {\"type\": \"object\"}\n",
-    "json_df = asyncio.run(openai_utils.get_all_responses(prompts=json_prompts, json_mode=True, expected_schema=schema, use_dummy=True, save_path=os.path.join(out_dir,'json.csv')))\n",
-    "json_df\n"
+    "\njson_prompts = ['{\"a\":1}', '{\"b\":2}']\nschema = {\"type\": \"object\"}\njson_df = await openai_utils.get_all_responses(prompts=json_prompts, json_mode=True, expected_schema=schema, use_dummy=True, save_path=os.path.join(out_dir,'json.csv'))\njson_df\n"
    ]
   },
   {
@@ -96,10 +107,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n",
-    "search_prompts = ['What is the capital of France?']\n",
-    "web_df = asyncio.run(openai_utils.get_all_responses(prompts=search_prompts, identifiers=['search'], use_web_search=True, use_dummy=True, save_path=os.path.join(out_dir,'web.csv')))\n",
-    "web_df\n"
+    "\nsearch_prompts = ['What is the capital of France?']\nweb_df = await openai_utils.get_all_responses(prompts=search_prompts, identifiers=['search'], use_web_search=True, use_dummy=True, save_path=os.path.join(out_dir,'web.csv'))\nweb_df\n"
    ]
   },
   {
@@ -117,13 +125,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n",
-    "resume_prompts = ['A1','A2','A3']\n",
-    "# First run with only two prompts\n",
-    "_ = asyncio.run(openai_utils.get_all_responses(prompts=resume_prompts[:2], identifiers=['r1','r2'], use_dummy=True, save_path=os.path.join(out_dir,'resume.csv')))\n",
-    "# Second run with all prompts (should only process missing one)\n",
-    "resume_df = asyncio.run(openai_utils.get_all_responses(prompts=resume_prompts, identifiers=['r1','r2','r3'], use_dummy=True, save_path=os.path.join(out_dir,'resume.csv')))\n",
-    "resume_df\n"
+    "\nresume_prompts = ['A1','A2','A3']\n# First run with only two prompts\n_ = await openai_utils.get_all_responses(prompts=resume_prompts[:2], identifiers=['r1','r2'], use_dummy=True, save_path=os.path.join(out_dir,'resume.csv'))\n# Second run with all prompts (should only process missing one)\nresume_df = await openai_utils.get_all_responses(prompts=resume_prompts, identifiers=['r1','r2','r3'], use_dummy=True, save_path=os.path.join(out_dir,'resume.csv'))\nresume_df\n"
    ]
   },
   {
@@ -141,11 +143,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n",
-    "data = pd.DataFrame({'text': ['This product is great.', 'Terrible experience.']})\n",
-    "ratings_cfg = RatingsConfig(attributes={'quality':'Overall quality'}, save_dir=os.path.join(out_dir,'ratings'), use_dummy=True)\n",
-    "ratings_res = asyncio.run(Ratings(ratings_cfg).run(data, text_column='text'))\n",
-    "ratings_res\n"
+    "\ndata = pd.DataFrame({'text': ['This product is great.', 'Terrible experience.']})\nratings_cfg = RatingsConfig(attributes={'quality':'Overall quality'}, save_dir=os.path.join(out_dir,'ratings'), use_dummy=True)\nratings_res = await Ratings(ratings_cfg).run(data, text_column='text')\nratings_res\n"
    ]
   },
   {
@@ -163,11 +161,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n",
-    "clf_data = pd.DataFrame({'txt': ['I love pizza', 'I hate spinach']})\n",
-    "clf_cfg = BasicClassifierConfig(labels={'positive':'Is the sentiment positive?'}, save_dir=os.path.join(out_dir,'classifier'), use_dummy=True)\n",
-    "clf_res = asyncio.run(BasicClassifier(clf_cfg).run(clf_data, text_column='txt'))\n",
-    "clf_res\n"
+    "\nclf_data = pd.DataFrame({'txt': ['I love pizza', 'I hate spinach']})\nclf_cfg = BasicClassifierConfig(labels={'positive':'Is the sentiment positive?'}, save_dir=os.path.join(out_dir,'classifier'), use_dummy=True)\nclf_res = await BasicClassifier(clf_cfg).run(clf_data, text_column='txt')\nclf_res\n"
    ]
   },
   {
@@ -185,11 +179,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n",
-    "deid_data = pd.DataFrame({'text':['John Doe went to New York.']})\n",
-    "deid_cfg = DeidentifyConfig(save_path=os.path.join(out_dir,'deid.csv'), use_dummy=True)\n",
-    "deid_res = asyncio.run(Deidentifier(deid_cfg).run(deid_data, text_column='text'))\n",
-    "deid_res\n"
+    "\ndeid_data = pd.DataFrame({'text':['John Doe went to New York.']})\ndeid_cfg = DeidentifyConfig(save_path=os.path.join(out_dir,'deid.csv'), use_dummy=True)\ndeid_res = await Deidentifier(deid_cfg).run(deid_data, text_column='text')\ndeid_res\n"
    ]
   },
   {
@@ -207,12 +197,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n",
-    "reg_data = pd.DataFrame({'county':['A','B']})\n",
-    "reg_cfg = RegionalConfig(save_dir=os.path.join(out_dir,'regional'), use_dummy=True)\n",
-    "regional_task = Regional(reg_data, 'county', topics=['economy'], cfg=reg_cfg)\n",
-    "regional_res = asyncio.run(regional_task.run())\n",
-    "regional_res\n"
+    "\nreg_data = pd.DataFrame({'county':['A','B']})\nreg_cfg = RegionalConfig(save_dir=os.path.join(out_dir,'regional'), use_dummy=True)\nregional_task = Regional(reg_data, 'county', topics=['economy'], cfg=reg_cfg)\nregional_res = await regional_task.run()\nregional_res\n"
    ]
   },
   {
@@ -230,11 +215,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n",
-    "county_data = pd.DataFrame({'county':['A','B'], 'fips':['00001','00002']})\n",
-    "cc = CountyCounter(county_data, county_col='county', topics=['econ'], fips_col='fips', save_dir=os.path.join(out_dir,'county'), use_dummy=True, n_elo_rounds=1)\n",
-    "county_res = asyncio.run(cc.run())\n",
-    "county_res\n"
+    "\ncounty_data = pd.DataFrame({'county':['A','B'], 'fips':['00001','00002']})\ncc = CountyCounter(county_data, county_col='county', topics=['econ'], fips_col='fips', save_dir=os.path.join(out_dir,'county'), use_dummy=True, n_elo_rounds=1)\ncounty_res = await cc.run()\ncounty_res\n"
    ]
   },
   {
@@ -252,13 +233,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n",
-    "elo_data = pd.DataFrame({'identifier':['x','y'], 'text':['Text X','Text Y']})\n",
-    "tele = Teleprompter()\n",
-    "elo_cfg = EloConfig(attributes={'clarity':''}, n_rounds=1, save_dir=os.path.join(out_dir,'elo'), use_dummy=True)\n",
-    "elo_task = EloRater(tele, elo_cfg)\n",
-    "elo_res = asyncio.run(elo_task.run(elo_data, text_col='text', id_col='identifier'))\n",
-    "elo_res\n"
+    "\nelo_data = pd.DataFrame({'identifier':['x','y'], 'text':['Text X','Text Y']})\ntele = Teleprompter()\nelo_cfg = EloConfig(attributes={'clarity':''}, n_rounds=1, save_dir=os.path.join(out_dir,'elo'), use_dummy=True)\nelo_task = EloRater(tele, elo_cfg)\nelo_res = await elo_task.run(elo_data, text_col='text', id_col='identifier')\nelo_res\n"
    ]
   },
   {
@@ -276,13 +251,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n",
-    "rec_data = pd.DataFrame({'identifier':['a','b','c'], 'text':['Alpha','Bravo','Charlie']})\n",
-    "base_cfg = EloConfig(attributes={'score':''}, n_rounds=1, save_dir=os.path.join(out_dir,'rec'), use_dummy=True)\n",
-    "rec_cfg = RecursiveEloConfig(base_cfg=base_cfg, min_remaining=2)\n",
-    "rec_task = RecursiveEloRater(tele, rec_cfg)\n",
-    "rec_res = asyncio.run(rec_task.run(rec_data, text_col='text', id_col='identifier'))\n",
-    "rec_res\n"
+    "\nrec_data = pd.DataFrame({'identifier':['a','b','c'], 'text':['Alpha','Bravo','Charlie']})\nbase_cfg = EloConfig(attributes={'score':''}, n_rounds=1, save_dir=os.path.join(out_dir,'rec'), use_dummy=True)\nrec_cfg = RecursiveEloConfig(base_cfg=base_cfg, min_remaining=2)\nrec_task = RecursiveEloRater(tele, rec_cfg)\nrec_res = await rec_task.run(rec_data, text_col='text', id_col='identifier')\nrec_res\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\nfrom gabriel.utils.parsing import safest_json\nfrom unittest.mock import patch\n\nasync def fake_response(*args, **kwargs):\n    return ['{\"good\": true}'], 0.0\n\nwith patch('gabriel.utils.openai_utils.get_response', fake_response):\n    fixed_json = await safest_json('{bad:1}')\nfixed_json\n"
    ]
   },
   {
@@ -296,15 +274,20 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\nbatch_prompts = [f'B{i}' for i in range(4)]\nbatch_df = await openai_utils.get_all_responses(\n    prompts=batch_prompts,\n    identifiers=[f'b{i}' for i in range(4)],\n    use_batch=True,\n    use_dummy=True,\n    save_path=os.path.join(out_dir,'batch.csv'),\n)\nbatch_df\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "6fa9cb5d",
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n",
-    "parap_cfg = PromptParaphraserConfig(n_variants=2, save_dir=os.path.join(out_dir,'parap'), use_dummy=True)\n",
-    "parap = PromptParaphraser(parap_cfg)\n",
-    "parap_res = asyncio.run(parap.run(Ratings, ratings_cfg, data, text_column='text'))\n",
-    "parap_res\n"
+    "\nparap_cfg = PromptParaphraserConfig(n_variants=2, save_dir=os.path.join(out_dir,'parap'), use_dummy=True)\nparap = PromptParaphraser(parap_cfg)\nparap_res = await parap.run(Ratings, ratings_cfg, data, text_column='text')\nparap_res\n"
    ]
   }
  ],

--- a/src/gabriel/tasks/recursive_elo.py
+++ b/src/gabriel/tasks/recursive_elo.py
@@ -10,7 +10,7 @@ from typing import Callable, Dict, List, Optional, Sequence, Tuple, Union, Any
 
 import pandas as pd
 
-from .elo_rater import EloRater, EloConfig  # adjust import path as needed
+from .elo import EloRater, EloConfig
 
 
 # ---------------------------------------------------------------------

--- a/src/gabriel/utils/openai_utils.py
+++ b/src/gabriel/utils/openai_utils.py
@@ -1115,51 +1115,46 @@ async def get_all_responses(
                                 timeout=nonlocal_timeout,
                                 use_dummy=use_dummy,
                                 verbose=verbose,
+                                images=prompt_images.get(str(ident)) if prompt_images else None,
                                 **get_response_kwargs,
                             ),
                             timeout=nonlocal_timeout,
-                            use_dummy=use_dummy,
-                            verbose=verbose,
-                            images=prompt_images.get(str(ident)) if prompt_images else None,
-                            **get_response_kwargs,
-                        ),
-                        timeout=nonlocal_timeout,
-                    )
-                    response_times.append(t)
-                    await adjust_timeout()
-                    # Check for empty outputs.  If all returned strings are empty or whitespace,
-                    # notify the user that the safety cutoff or tier limits may have truncated the output.
-                    if resps and all((isinstance(r, str) and not r.strip()) for r in resps):
-                        if verbose:
-                            print(
-                                f"[get_all_responses] Timeout on attempt {attempt} for {ident} after {nonlocal_timeout:.1f}s. Consider increasing the 'timeout' parameter if timeouts persist."
-                            )
-                        if (
-                            dynamic_timeout
-                            and call_count > 0
-                            and timeout_errors / call_count > 0.05
-                        ):
-                            if len(response_times) >= min_samples_for_timeout:
-                                try:
-                                    sorted_times = sorted(response_times)
-                                    q95_index = max(0, int(0.95 * (len(sorted_times) - 1)))
-                                    q95 = sorted_times[q95_index]
-                                    new_t = min(
-                                        max_timeout,
-                                        max(nonlocal_timeout, timeout_factor * q95),
-                                    )
-                                except Exception:
-                                    new_t = min(
-                                        max_timeout, nonlocal_timeout * timeout_factor
-                                    )
-                            else:
-                                new_t = min(max_timeout, nonlocal_timeout * timeout_factor)
-                            if new_t > nonlocal_timeout:
-                                if verbose:
-                                    print(
-                                        f"[dynamic timeout] Increasing timeout to {new_t:.1f}s due to high timeout rate."
-                                    )
-                                nonlocal_timeout = new_t
+                        )
+                        response_times.append(t)
+                        await adjust_timeout()
+                        # Check for empty outputs.  If all returned strings are empty or whitespace,
+                        # notify the user that the safety cutoff or tier limits may have truncated the output.
+                        if resps and all((isinstance(r, str) and not r.strip()) for r in resps):
+                            if verbose:
+                                print(
+                                    f"[get_all_responses] Timeout on attempt {attempt} for {ident} after {nonlocal_timeout:.1f}s. Consider increasing the 'timeout' parameter if timeouts persist."
+                                )
+                            if (
+                                dynamic_timeout
+                                and call_count > 0
+                                and timeout_errors / call_count > 0.05
+                            ):
+                                if len(response_times) >= min_samples_for_timeout:
+                                    try:
+                                        sorted_times = sorted(response_times)
+                                        q95_index = max(0, int(0.95 * (len(sorted_times) - 1)))
+                                        q95 = sorted_times[q95_index]
+                                        new_t = min(
+                                            max_timeout,
+                                            max(nonlocal_timeout, timeout_factor * q95),
+                                        )
+                                    except Exception:
+                                        new_t = min(
+                                            max_timeout, nonlocal_timeout * timeout_factor
+                                        )
+                                else:
+                                    new_t = min(max_timeout, nonlocal_timeout * timeout_factor)
+                                if new_t > nonlocal_timeout:
+                                    if verbose:
+                                        print(
+                                            f"[dynamic timeout] Increasing timeout to {new_t:.1f}s due to high timeout rate."
+                                        )
+                                    nonlocal_timeout = new_t
                         if attempt >= max_retries:
                             results.append(
                                 {"Identifier": ident, "Response": None, "Time Taken": None}

--- a/src/gabriel/utils/parsing.py
+++ b/src/gabriel/utils/parsing.py
@@ -73,7 +73,7 @@ async def safest_json(txt: Any, *, model: str | None = None) -> dict | list:
         if model is None:
             model = JSON_LLM_MODEL
         from gabriel.utils.openai_utils import get_response
-
+        use_dummy = model == "dummy"
         fixed, _ = await get_response(
             prompt=(
                 "Please parse the following text **without changing any content** "
@@ -81,6 +81,7 @@ async def safest_json(txt: Any, *, model: str | None = None) -> dict | list:
             ),
             model=model,
             json_mode=True,
+            use_dummy=use_dummy,
         )
         if fixed:
             try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,3 +2,4 @@ import os
 import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+os.environ.setdefault("JSON_LLM_MODEL", "dummy")


### PR DESCRIPTION
## Summary
- fix broken import in `recursive_elo`
- handle dummy model in `safest_json`
- repair `openai_utils` wait_for call
- allow tests to set `JSON_LLM_MODEL` via `conftest`
- greatly expand the stress test notebook with more async examples and batch mode

## Testing
- `pip install -e .[dev] -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887cfe4a0d48332b4e25d812b61a8b4