### PR TITLE
Improve library stress example and add Jinja filters

### DIFF
--- a/examples/library_stress_test.ipynb
+++ b/examples/library_stress_test.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# GABRIEL Library Stress Test\n",
     "\n",
-    "This notebook exercises various API calls and pipelines in dummy mode to verify the library works as expected. All OpenAI calls use the built-in dummy responses, so it can run offline and be re-run safely."
+    "This notebook exercises various API calls and pipelines using real OpenAI responses. Ensure you have API access before running. All calls set `use_dummy=False`.\n"
    ]
   },
   {
@@ -44,7 +44,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\ntry:\n    from sklearn.datasets import fetch_20newsgroups\n    ng = fetch_20newsgroups(subset='train', categories=['sci.space'], remove=('headers','footers','quotes'), download_if_missing=False)\n    sample_texts = ng.data[:3]\nexcept Exception:\n    sample_texts = ['Space exploration','Galaxy news','Astronomy facts']\n"
+    "\ntry:\n    from sklearn.datasets import fetch_20newsgroups\n    ng = fetch_20newsgroups(subset='train', categories=['sci.space'], remove=('headers','footers','quotes'), download_if_missing=False)\n    sample_texts = ng.data[:8]\nexcept Exception:\n    sample_texts = [\n        'Space exploration has entered a new golden age with private companies.',\n        'Astronomers recently discovered water on a distant exoplanet.',\n        'Rockets are becoming reusable thanks to modern engineering.',\n        'Satellite technology enables global internet coverage.',\n        'Mars missions are planned for the next decade.',\n        'The International Space Station hosts numerous experiments.',\n        'Studying cosmic radiation helps us understand the universe.',\n        'Observatories around the world capture images of distant galaxies.',\n    ]\n"
    ]
   },
   {
@@ -53,7 +53,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\nng_df = await openai_utils.get_all_responses(prompts=sample_texts, identifiers=['ng1','ng2','ng3'], use_dummy=True, save_path=os.path.join(out_dir,'ng.csv'))\nng_df\n"
+    "\nng_df = await openai_utils.get_all_responses(\n    prompts=sample_texts,\n    identifiers=[f'ng{i}' for i in range(1, len(sample_texts)+1)],\n    use_dummy=False,\n    save_path=os.path.join(out_dir,'ng.csv')\n)\nng_df\n"
    ]
   },
   {
@@ -71,7 +71,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\nprompts = ['Hello world', 'How are you?']\ndf = await openai_utils.get_all_responses(prompts=prompts, identifiers=['p1','p2'], use_dummy=True, save_path=os.path.join(out_dir,'basic.csv'))\ndf\n"
+    "\nprompts = [\n    'Summarize the plot of Hamlet in two sentences.',\n    'Explain the theory of general relativity in simple terms.',\n    'Describe how photosynthesis works.',\n    'Give three reasons why exercise is beneficial.',\n    'Outline the history of the Internet.',\n    'What causes thunderstorms to form?',\n    'Provide a short biography of Ada Lovelace.',\n    'How does blockchain technology maintain security?',\n    'List important features of a democratic government.',\n    'Why is biodiversity important for ecosystems?'\n]\ndf = await openai_utils.get_all_responses(\n    prompts=prompts,\n    identifiers=[f'p{i}' for i in range(1, len(prompts)+1)],\n    use_dummy=False,\n    save_path=os.path.join(out_dir,'basic.csv')\n)\ndf\n"
    ]
   },
   {
@@ -89,7 +89,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\njson_prompts = ['{\"a\":1}', '{\"b\":2}']\nschema = {\"type\": \"object\"}\njson_df = await openai_utils.get_all_responses(prompts=json_prompts, json_mode=True, expected_schema=schema, use_dummy=True, save_path=os.path.join(out_dir,'json.csv'))\njson_df\n"
+    "\njson_prompts = [\n    'Create a JSON object with keys \"name\", \"age\", and \"city\" for a fictional person named Alice who is 30 and lives in Denver.',\n    'Provide JSON describing a product with fields \"id\", \"description\", and \"price\" for a laptop that costs 999.'\n]\nschema = {\"type\": \"object\"}\njson_df = await openai_utils.get_all_responses(\n    prompts=json_prompts,\n    json_mode=True,\n    expected_schema=schema,\n    use_dummy=False,\n    save_path=os.path.join(out_dir,'json.csv')\n)\njson_df\n"
    ]
   },
   {
@@ -107,7 +107,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\nsearch_prompts = ['What is the capital of France?']\nweb_df = await openai_utils.get_all_responses(prompts=search_prompts, identifiers=['search'], use_web_search=True, use_dummy=True, save_path=os.path.join(out_dir,'web.csv'))\nweb_df\n"
+    "\nsearch_prompts = [\n    'What is the tallest mountain in Africa and who led the first recorded ascent?'\n]\nweb_df = await openai_utils.get_all_responses(\n    prompts=search_prompts,\n    identifiers=['search1'],\n    use_web_search=True,\n    use_dummy=False,\n    save_path=os.path.join(out_dir,'web.csv')\n)\nweb_df\n"
    ]
   },
   {
@@ -125,7 +125,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\nresume_prompts = ['A1','A2','A3']\n# First run with only two prompts\n_ = await openai_utils.get_all_responses(prompts=resume_prompts[:2], identifiers=['r1','r2'], use_dummy=True, save_path=os.path.join(out_dir,'resume.csv'))\n# Second run with all prompts (should only process missing one)\nresume_df = await openai_utils.get_all_responses(prompts=resume_prompts, identifiers=['r1','r2','r3'], use_dummy=True, save_path=os.path.join(out_dir,'resume.csv'))\nresume_df\n"
+    "\nresume_prompts = [\n    'Define artificial intelligence.',\n    'What are neural networks used for?',\n    'Explain the Turing test.',\n    'Describe the concept of machine learning.',\n    'List applications of computer vision.'\n]\n# First run with only three prompts\n_ = await openai_utils.get_all_responses(\n    prompts=resume_prompts[:3],\n    identifiers=[f'r{i}' for i in range(1,4)],\n    use_dummy=False,\n    save_path=os.path.join(out_dir,'resume.csv')\n)\n# Second run with all prompts (should only process remaining ones)\nresume_df = await openai_utils.get_all_responses(\n    prompts=resume_prompts,\n    identifiers=[f'r{i}' for i in range(1,6)],\n    use_dummy=False,\n    save_path=os.path.join(out_dir,'resume.csv')\n)\nresume_df\n"
    ]
   },
   {
@@ -143,7 +143,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\ndata = pd.DataFrame({'text': ['This product is great.', 'Terrible experience.']})\nratings_cfg = RatingsConfig(attributes={'quality':'Overall quality'}, save_dir=os.path.join(out_dir,'ratings'), use_dummy=True)\nratings_res = await Ratings(ratings_cfg).run(data, text_column='text')\nratings_res\n"
+    "\ndata = pd.DataFrame({'text': [\n    'The new smartphone release offers cutting-edge features and sleek design.',\n    'Customer support was unhelpful and slow to respond.'\n]})\nratings_cfg = RatingsConfig(\n    attributes={\n        'clarity': 'Is the text easy to understand?',\n        'detail': 'Does the text provide sufficient detail?',\n        'tone': 'Assess the overall tone.'\n    },\n    save_dir=os.path.join(out_dir,'ratings'),\n    use_dummy=False\n)\nratings_res = await Ratings(ratings_cfg).run(data, text_column='text')\nratings_res\n"
    ]
   },
   {
@@ -161,7 +161,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\nclf_data = pd.DataFrame({'txt': ['I love pizza', 'I hate spinach']})\nclf_cfg = BasicClassifierConfig(labels={'positive':'Is the sentiment positive?'}, save_dir=os.path.join(out_dir,'classifier'), use_dummy=True)\nclf_res = await BasicClassifier(clf_cfg).run(clf_data, text_column='txt')\nclf_res\n"
+    "\nclf_data = pd.DataFrame({'txt': [\n    'I absolutely loved the new movie!',\n    'The service at the restaurant was terrible.',\n    'It was an average experience overall.'\n]})\nclf_cfg = BasicClassifierConfig(\n    labels={\n        'positive': 'Is the sentiment positive?',\n        'negative': 'Is the sentiment negative?',\n        'neutral': 'Is the sentiment neutral?'\n    },\n    save_dir=os.path.join(out_dir,'classifier'),\n    use_dummy=False\n)\nclf_res = await BasicClassifier(clf_cfg).run(clf_data, text_column='txt')\nclf_res\n"
    ]
   },
   {
@@ -179,7 +179,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\ndeid_data = pd.DataFrame({'text':['John Doe went to New York.']})\ndeid_cfg = DeidentifyConfig(save_path=os.path.join(out_dir,'deid.csv'), use_dummy=True)\ndeid_res = await Deidentifier(deid_cfg).run(deid_data, text_column='text')\ndeid_res\n"
+    "\ndeid_data = pd.DataFrame({'text': [\n    'Jane Doe met with Dr. Smith in New York on July 4th, 2021.',\n    'Contact me at 555-123-4567 or email john@example.com.'\n]})\ndeid_cfg = DeidentifyConfig(\n    save_path=os.path.join(out_dir,'deid.csv'),\n    use_dummy=False\n)\ndeid_res = await Deidentifier(deid_cfg).run(deid_data, text_column='text')\ndeid_res\n"
    ]
   },
   {
@@ -197,7 +197,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\nreg_data = pd.DataFrame({'county':['A','B']})\nreg_cfg = RegionalConfig(save_dir=os.path.join(out_dir,'regional'), use_dummy=True)\nregional_task = Regional(reg_data, 'county', topics=['economy'], cfg=reg_cfg)\nregional_res = await regional_task.run()\nregional_res\n"
+    "\nreg_data = pd.DataFrame({'county': ['A', 'B', 'C']})\nreg_cfg = RegionalConfig(\n    save_dir=os.path.join(out_dir,'regional'),\n    use_dummy=False\n)\nregional_task = Regional(reg_data, 'county', topics=['economy', 'public safety'], cfg=reg_cfg)\nregional_res = await regional_task.run()\nregional_res\n"
    ]
   },
   {
@@ -215,7 +215,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\ncounty_data = pd.DataFrame({'county':['A','B'], 'fips':['00001','00002']})\ncc = CountyCounter(county_data, county_col='county', topics=['econ'], fips_col='fips', save_dir=os.path.join(out_dir,'county'), use_dummy=True, n_elo_rounds=1)\ncounty_res = await cc.run()\ncounty_res\n"
+    "\ncounty_data = pd.DataFrame({\n    'county': ['A', 'B', 'C'],\n    'fips': ['00001', '00002', '00003']\n})\ncc = CountyCounter(\n    county_data,\n    county_col='county',\n    topics=['econ', 'health'],\n    fips_col='fips',\n    save_dir=os.path.join(out_dir,'county'),\n    use_dummy=False,\n    n_elo_rounds=1\n)\ncounty_res = await cc.run()\ncounty_res\n"
    ]
   },
   {
@@ -233,7 +233,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\nelo_data = pd.DataFrame({'identifier':['x','y'], 'text':['Text X','Text Y']})\ntele = Teleprompter()\nelo_cfg = EloConfig(attributes={'clarity':''}, n_rounds=1, save_dir=os.path.join(out_dir,'elo'), use_dummy=True)\nelo_task = EloRater(tele, elo_cfg)\nelo_res = await elo_task.run(elo_data, text_col='text', id_col='identifier')\nelo_res\n"
+    "\nelo_data = pd.DataFrame({'identifier':['x','y'], 'text':['Text X with clear explanation','Text Y with vague content']})\ntele = Teleprompter()\nelo_cfg = EloConfig(\n    attributes={'clarity':'', 'informativeness':''},\n    n_rounds=2,\n    save_dir=os.path.join(out_dir,'elo'),\n    use_dummy=False\n)\nelo_task = EloRater(tele, elo_cfg)\nelo_res = await elo_task.run(elo_data, text_col='text', id_col='identifier')\nelo_res\n"
    ]
   },
   {
@@ -251,7 +251,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\nrec_data = pd.DataFrame({'identifier':['a','b','c'], 'text':['Alpha','Bravo','Charlie']})\nbase_cfg = EloConfig(attributes={'score':''}, n_rounds=1, save_dir=os.path.join(out_dir,'rec'), use_dummy=True)\nrec_cfg = RecursiveEloConfig(base_cfg=base_cfg, min_remaining=2)\nrec_task = RecursiveEloRater(tele, rec_cfg)\nrec_res = await rec_task.run(rec_data, text_col='text', id_col='identifier')\nrec_res\n"
+    "\nrec_data = pd.DataFrame({'identifier':['a','b','c','d'], 'text':['Alpha text','Bravo text','Charlie text','Delta text']})\nbase_cfg = EloConfig(\n    attributes={'score':''},\n    n_rounds=1,\n    save_dir=os.path.join(out_dir,'rec'),\n    use_dummy=False\n)\nrec_cfg = RecursiveEloConfig(base_cfg=base_cfg, min_remaining=2)\nrec_task = RecursiveEloRater(tele, rec_cfg)\nrec_res = await rec_task.run(rec_data, text_col='text', id_col='identifier')\nrec_res\n"
    ]
   },
   {
@@ -277,7 +277,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\nbatch_prompts = [f'B{i}' for i in range(4)]\nbatch_df = await openai_utils.get_all_responses(\n    prompts=batch_prompts,\n    identifiers=[f'b{i}' for i in range(4)],\n    use_batch=True,\n    use_dummy=True,\n    save_path=os.path.join(out_dir,'batch.csv'),\n)\nbatch_df\n"
+    "\nbatch_prompts = [f'Batch prompt {i}' for i in range(1,9)]\nbatch_df = await openai_utils.get_all_responses(\n    prompts=batch_prompts,\n    identifiers=[f'b{i}' for i in range(1,9)],\n    use_batch=True,\n    use_dummy=False,\n    save_path=os.path.join(out_dir,'batch.csv'),\n)\nbatch_df\n"
    ]
   },
   {
@@ -287,7 +287,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\nparap_cfg = PromptParaphraserConfig(n_variants=2, save_dir=os.path.join(out_dir,'parap'), use_dummy=True)\nparap = PromptParaphraser(parap_cfg)\nparap_res = await parap.run(Ratings, ratings_cfg, data, text_column='text')\nparap_res\n"
+    "\nparap_cfg = PromptParaphraserConfig(\n    n_variants=3,\n    save_dir=os.path.join(out_dir,'parap'),\n    use_dummy=False\n)\nparap = PromptParaphraser(parap_cfg)\nparap_res = await parap.run(Ratings, ratings_cfg, data, text_column='text')\nparap_res\n"
    ]
   }
  ],

--- a/src/gabriel/core/prompt_template.py
+++ b/src/gabriel/core/prompt_template.py
@@ -1,8 +1,30 @@
 """Prompt template utilities."""
 from dataclasses import dataclass
 from importlib import resources
-from jinja2 import Template
+from jinja2 import Environment, Template
+import random
 from typing import Dict
+
+
+def _shuffled_dict(value) -> Dict[str, str]:
+    """Return a new dict with items in random order."""
+    if isinstance(value, dict):
+        items = list(value.items())
+        random.shuffle(items)
+        return dict(items)
+    else:
+        items = list(value)
+        random.shuffle(items)
+        return {k: k for k in items}
+
+
+def _shuffled(value):
+    if isinstance(value, dict):
+        items = list(value.keys())
+    else:
+        items = list(value)
+    random.shuffle(items)
+    return items
 
 @dataclass
 class PromptTemplate:
@@ -12,7 +34,18 @@ class PromptTemplate:
 
     def render(self, **params: Dict[str, str]) -> str:
         """Render the template with the given parameters."""
-        return Template(self.text).render(**params)
+        attrs = params.get("attributes")
+        descs = params.get("descriptions")
+        if isinstance(attrs, list):
+            if isinstance(descs, list) and len(descs) == len(attrs):
+                params["attributes"] = {a: d for a, d in zip(attrs, descs)}
+            else:
+                params["attributes"] = {a: a for a in attrs}
+        env = Environment()
+        env.filters["shuffled_dict"] = _shuffled_dict
+        env.filters["shuffled"] = _shuffled
+        template = env.from_string(self.text)
+        return template.render(**params)
 
     @classmethod
     def from_package(

--- a/src/gabriel/utils/teleprompter.py
+++ b/src/gabriel/utils/teleprompter.py
@@ -4,6 +4,27 @@ import os
 from typing import Dict, List, Union
 
 from jinja2 import Environment, FileSystemLoader
+import random
+
+
+def _shuffled_dict(value) -> Dict[str, str]:
+    if isinstance(value, dict):
+        items = list(value.items())
+        random.shuffle(items)
+        return dict(items)
+    else:
+        items = list(value)
+        random.shuffle(items)
+        return {k: k for k in items}
+
+
+def _shuffled(value):
+    if isinstance(value, dict):
+        items = list(value.keys())
+    else:
+        items = list(value)
+    random.shuffle(items)
+    return items
 
 
 class Teleprompter:
@@ -13,6 +34,8 @@ class Teleprompter:
         if prompt_path is None:
             prompt_path = os.path.join(os.path.dirname(__file__), "..", "prompts")
         self.env = Environment(loader=FileSystemLoader(os.path.abspath(prompt_path)))
+        self.env.filters["shuffled_dict"] = _shuffled_dict
+        self.env.filters["shuffled"] = _shuffled
 
     def generic_elo_prompt(
         self,


### PR DESCRIPTION
## Summary
- expand `library_stress_test.ipynb` with real prompts and `use_dummy=False`
- add shuffle filters to `PromptTemplate` and `Teleprompter`
- handle attribute lists in `PromptTemplate.render`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887dcf8d1188332a7bbe586fc1aee26