### PR TITLE
Fix successful response handling in get_all_responses

### DIFF
--- a/src/gabriel/utils/openai_utils.py
+++ b/src/gabriel/utils/openai_utils.py
@@ -1155,6 +1155,13 @@ async def get_all_responses(
                                             f"[dynamic timeout] Increasing timeout to {new_t:.1f}s due to high timeout rate."
                                         )
                                     nonlocal_timeout = new_t
+                        else:
+                            results.append({"Identifier": ident, "Response": resps, "Time Taken": t})
+                            processed += 1
+                            pbar.update(1)
+                            if processed % save_every_x_responses == 0:
+                                await flush()
+                            break
                         if attempt >= max_retries:
                             results.append(
                                 {"Identifier": ident, "Response": None, "Time Taken": None}


### PR DESCRIPTION
## Summary
- ensure `get_all_responses` records successful API responses

## Testing
- `pytest -q`
- `pytest tests/test_basic.py::test_prompt_paraphraser_ratings -q`


------
https://chatgpt.com/codex/tasks/task_e_6887f048904483329d792fd9115f7071