### PR TITLE
Fix Ratings prompt parameter names

### DIFF
--- a/src/gabriel/tasks/ratings.py
+++ b/src/gabriel/tasks/ratings.py
@@ -115,13 +115,10 @@ class Ratings:
                 continue
             prompts.append(
                 self.template.render(
-                    attributes=list(self.cfg.attributes.keys()),
-                    descriptions=list(self.cfg.attributes.values()),
-                    passage=passage,
-                    object_category="text",
-                    attribute_category="attributes",
-                    rating_scale=self.cfg.rating_scale,
-                    additional_guidelines=self.cfg.additional_guidelines,
+                    text=passage,
+                    attributes=self.cfg.attributes,
+                    scale=self.cfg.rating_scale,
+                    additional_instructions=self.cfg.additional_guidelines,
                 )
             )
             ids.append(sha8)


### PR DESCRIPTION
## Summary
- fix Ratings task to pass correct variable names to prompt

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887f4c162348332a42a3d058267bf72