### PR TITLE
Refactor ratings task and add simple API helpers

### DIFF
--- a/src/gabriel/__init__.py
+++ b/src/gabriel/__init__.py
@@ -3,13 +3,14 @@
 from importlib.metadata import PackageNotFoundError, version as _v
 
 from . import tasks as _tasks
+from .api import rate, classify
 
 try:
     __version__ = _v("gabriel")
 except PackageNotFoundError:  # pragma: no cover - package not installed
     from ._version import __version__
 
-__all__ = list(_tasks.__all__)
+__all__ = list(_tasks.__all__) + ["rate", "classify"]
 
 
 def __getattr__(name: str):

--- a/src/gabriel/api.py
+++ b/src/gabriel/api.py
@@ -1,0 +1,70 @@
+import asyncio
+import os
+import pandas as pd
+
+from .tasks import (
+    Ratings,
+    RatingsConfig,
+    BasicClassifier,
+    BasicClassifierConfig,
+)
+
+
+def rate(
+    df: pd.DataFrame,
+    column_name: str,
+    *,
+    attributes: dict[str, str],
+    save_dir: str,
+    additional_instructions: str | None = None,
+    model: str = "o4-mini",
+    n_parallels: int = 100,
+    reset_files: bool = False,
+    use_dummy: bool = False,
+    file_name: str = "ratings.csv",
+    **cfg_kwargs,
+) -> pd.DataFrame:
+    """Convenience wrapper for :class:`gabriel.tasks.Ratings`."""
+    os.makedirs(save_dir, exist_ok=True)
+    cfg = RatingsConfig(
+        attributes=attributes,
+        save_dir=save_dir,
+        file_name=file_name,
+        model=model,
+        n_parallels=n_parallels,
+        use_dummy=use_dummy,
+        additional_instructions=additional_instructions,
+        **cfg_kwargs,
+    )
+    return asyncio.run(Ratings(cfg).run(df, column_name, reset_files=reset_files))
+
+
+def classify(
+    df: pd.DataFrame,
+    column_name: str,
+    *,
+    labels: dict[str, str],
+    save_dir: str,
+    additional_instructions: str | None = None,
+    model: str = "o4-mini",
+    n_parallels: int = 400,
+    reset_files: bool = False,
+    use_dummy: bool = False,
+    file_name: str = "basic_classifier_responses.csv",
+    **cfg_kwargs,
+) -> pd.DataFrame:
+    """Convenience wrapper for :class:`gabriel.tasks.BasicClassifier`."""
+    os.makedirs(save_dir, exist_ok=True)
+    cfg = BasicClassifierConfig(
+        labels=labels,
+        save_dir=save_dir,
+        file_name=file_name,
+        model=model,
+        n_parallels=n_parallels,
+        additional_instructions=additional_instructions or "",
+        use_dummy=use_dummy,
+        **cfg_kwargs,
+    )
+    return asyncio.run(
+        BasicClassifier(cfg).run(df, column_name, reset_files=reset_files)
+    )

--- a/src/gabriel/core/prompt_template.py
+++ b/src/gabriel/core/prompt_template.py
@@ -2,29 +2,9 @@
 from dataclasses import dataclass
 from importlib import resources
 from jinja2 import Environment, Template
-import random
 from typing import Dict
 
-
-def _shuffled_dict(value) -> Dict[str, str]:
-    """Return a new dict with items in random order."""
-    if isinstance(value, dict):
-        items = list(value.items())
-        random.shuffle(items)
-        return dict(items)
-    else:
-        items = list(value)
-        random.shuffle(items)
-        return {k: k for k in items}
-
-
-def _shuffled(value):
-    if isinstance(value, dict):
-        items = list(value.keys())
-    else:
-        items = list(value)
-    random.shuffle(items)
-    return items
+from ..utils.jinja import shuffled, shuffled_dict
 
 @dataclass
 class PromptTemplate:
@@ -42,8 +22,8 @@ class PromptTemplate:
             else:
                 params["attributes"] = {a: a for a in attrs}
         env = Environment()
-        env.filters["shuffled_dict"] = _shuffled_dict
-        env.filters["shuffled"] = _shuffled
+        env.filters["shuffled_dict"] = shuffled_dict
+        env.filters["shuffled"] = shuffled
         template = env.from_string(self.text)
         return template.render(**params)
 

--- a/src/gabriel/utils/__init__.py
+++ b/src/gabriel/utils/__init__.py
@@ -7,6 +7,7 @@ from .teleprompter import Teleprompter
 from .maps import create_county_choropleth
 from .prompt_paraphraser import PromptParaphraser, PromptParaphraserConfig
 from .parsing import safe_json, safest_json
+from .jinja import shuffled, shuffled_dict, get_env
 
 __all__ = [
     "get_response",
@@ -19,4 +20,7 @@ __all__ = [
     "safe_json",
     "safest_json",
     "encode_image",
+    "shuffled",
+    "shuffled_dict",
+    "get_env",
 ]

--- a/src/gabriel/utils/jinja.py
+++ b/src/gabriel/utils/jinja.py
@@ -1,0 +1,29 @@
+import os
+import random
+from collections import OrderedDict
+from jinja2 import Environment, FileSystemLoader
+
+
+def shuffled(it, seed=None):
+    """Return a new list with the same elements, shuffled."""
+    seq = list(it)
+    rnd = random.Random(seed) if seed is not None else random
+    rnd.shuffle(seq)
+    return seq
+
+
+def shuffled_dict(d, seed=None):
+    """Return an ordered dict with items shuffled."""
+    items = list(d.items())
+    rnd = random.Random(seed) if seed is not None else random
+    rnd.shuffle(items)
+    return OrderedDict(items)
+
+
+def get_env():
+    """Return a Jinja2 environment with shuffle filters preloaded."""
+    templates_dir = os.path.join(os.path.dirname(__file__), "..", "prompts")
+    env = Environment(loader=FileSystemLoader(os.path.abspath(templates_dir)))
+    env.filters["shuffled"] = shuffled
+    env.filters["shuffled_dict"] = shuffled_dict
+    return env

--- a/src/gabriel/utils/teleprompter.py
+++ b/src/gabriel/utils/teleprompter.py
@@ -4,27 +4,8 @@ import os
 from typing import Dict, List, Union
 
 from jinja2 import Environment, FileSystemLoader
-import random
 
-
-def _shuffled_dict(value) -> Dict[str, str]:
-    if isinstance(value, dict):
-        items = list(value.items())
-        random.shuffle(items)
-        return dict(items)
-    else:
-        items = list(value)
-        random.shuffle(items)
-        return {k: k for k in items}
-
-
-def _shuffled(value):
-    if isinstance(value, dict):
-        items = list(value.keys())
-    else:
-        items = list(value)
-    random.shuffle(items)
-    return items
+from .jinja import shuffled, shuffled_dict
 
 
 class Teleprompter:
@@ -34,8 +15,8 @@ class Teleprompter:
         if prompt_path is None:
             prompt_path = os.path.join(os.path.dirname(__file__), "..", "prompts")
         self.env = Environment(loader=FileSystemLoader(os.path.abspath(prompt_path)))
-        self.env.filters["shuffled_dict"] = _shuffled_dict
-        self.env.filters["shuffled"] = _shuffled
+        self.env.filters["shuffled_dict"] = shuffled_dict
+        self.env.filters["shuffled"] = shuffled
 
     def generic_elo_prompt(
         self,

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -10,6 +10,7 @@ from gabriel.tasks.basic_classifier import BasicClassifier, BasicClassifierConfi
 from gabriel.tasks.regional import Regional, RegionalConfig
 from gabriel.tasks.county_counter import CountyCounter
 from gabriel.utils import PromptParaphraser, PromptParaphraserConfig
+import gabriel
 
 
 def test_prompt_template():
@@ -119,4 +120,25 @@ def test_prompt_paraphraser_ratings(tmp_path):
     data = pd.DataFrame({"txt": ["hello"]})
     df = asyncio.run(paraphraser.run(Ratings, cfg, data, text_column="txt"))
     assert set(df.prompt_variant) == {"baseline", "variant_1", "variant_2"}
+
+
+def test_api_wrappers(tmp_path):
+    df = pd.DataFrame({"txt": ["hello"]})
+    rated = gabriel.rate(
+        df,
+        "txt",
+        attributes={"clarity": ""},
+        save_dir=str(tmp_path / "rate"),
+        use_dummy=True,
+    )
+    assert "clarity" in rated.columns
+
+    classified = gabriel.classify(
+        df,
+        "txt",
+        labels={"yes": ""},
+        save_dir=str(tmp_path / "cls"),
+        use_dummy=True,
+    )
+    assert "yes" in classified.columns
 


### PR DESCRIPTION
## Summary
- clean up ratings parsing logic
- expose shuffle utilities and Jinja environment helpers
- update PromptTemplate and Teleprompter to use new helpers
- add convenience `rate` and `classify` API functions
- expand tests for new API wrappers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888162f00788332a6d935b30985d185