### PR TITLE
Implement multi-run ratings and classification

### DIFF
--- a/src/gabriel/api.py
+++ b/src/gabriel/api.py
@@ -9,7 +9,7 @@ from .tasks import (
     BasicClassifierConfig,
 )
 
-async def rate(
+def rate(
     df: pd.DataFrame,
     column_name: str,
     *,
@@ -18,6 +18,7 @@ async def rate(
     additional_instructions: str | None = None,
     model: str = "o4-mini",
     n_parallels: int = 100,
+    n_runs: int = 1,
     reset_files: bool = False,
     use_dummy: bool = False,
     file_name: str = "ratings.csv",
@@ -31,13 +32,14 @@ async def rate(
         file_name=file_name,
         model=model,
         n_parallels=n_parallels,
+        n_runs=n_runs,
         use_dummy=use_dummy,
         additional_instructions=additional_instructions,
         **cfg_kwargs,
     )
-    return await Ratings(cfg).run(df, column_name, reset_files=reset_files)
+    return asyncio.run(Ratings(cfg).run(df, column_name, reset_files=reset_files))
 
-async def classify(
+def classify(
     df: pd.DataFrame,
     column_name: str,
     *,
@@ -46,6 +48,7 @@ async def classify(
     additional_instructions: str | None = None,
     model: str = "o4-mini",
     n_parallels: int = 400,
+    n_runs: int = 1,
     reset_files: bool = False,
     use_dummy: bool = False,
     file_name: str = "basic_classifier_responses.csv",
@@ -59,8 +62,9 @@ async def classify(
         file_name=file_name,
         model=model,
         n_parallels=n_parallels,
+        n_runs=n_runs,
         additional_instructions=additional_instructions or "",
         use_dummy=use_dummy,
         **cfg_kwargs,
     )
-    return await BasicClassifier(cfg).run(df, column_name, reset_files=reset_files)
+    return asyncio.run(BasicClassifier(cfg).run(df, column_name, reset_files=reset_files))

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -69,6 +69,16 @@ def test_ratings_dummy(tmp_path):
     assert "helpfulness" in df.columns
 
 
+def test_ratings_multirun(tmp_path):
+    cfg = RatingsConfig(attributes={"helpfulness": ""}, save_dir=str(tmp_path), file_name="ratings.csv", use_dummy=True, n_runs=2)
+    task = Ratings(cfg)
+    data = pd.DataFrame({"text": ["hello"]})
+    df = asyncio.run(task.run(data, text_column="text"))
+    assert "helpfulness" in df.columns
+    disagg = pd.read_csv(tmp_path / "ratings_full_disaggregated.csv", index_col=[0, 1])
+    assert set(disagg.index.names) == {"text", "run"}
+
+
 def test_deidentifier_dummy(tmp_path):
     cfg = DeidentifyConfig(save_path=str(tmp_path/"deid.csv"), use_dummy=True)
     task = Deidentifier(cfg)
@@ -83,6 +93,16 @@ def test_basic_classifier_dummy(tmp_path):
     df = pd.DataFrame({"txt": ["a", "b"]})
     res = asyncio.run(task.run(df, text_column="txt"))
     assert "yes" in res.columns
+
+
+def test_basic_classifier_multirun(tmp_path):
+    cfg = BasicClassifierConfig(labels={"yes": ""}, save_dir=str(tmp_path), use_dummy=True, n_runs=2)
+    task = BasicClassifier(cfg)
+    df = pd.DataFrame({"txt": ["a"]})
+    res = asyncio.run(task.run(df, text_column="txt"))
+    assert "yes" in res.columns
+    disagg = pd.read_csv(tmp_path / "basic_classifier_responses_full_disaggregated.csv", index_col=[0, 1])
+    assert set(disagg.index.names) == {"text", "run"}
 
 
 def test_regional_dummy(tmp_path):


### PR DESCRIPTION
## Summary
- add `n_runs` to ratings and classification configs
- implement multi-run logic for `Ratings` and `BasicClassifier`
- expose `n_runs` in API wrappers
- add regression tests for multi-run mode

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68881de3e41c8332a74249e0937a8f89