### PR TITLE
Fix ratings scale default handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Key options (see `RatingsConfig`):
 - `model` – model name (default `o4-mini`).
 - `n_parallels` – number of concurrent API calls.
 - `save_path` – CSV file for intermediate results.
+- `rating_scale` – optional custom rating scale text. If omitted, the default 0–100 scale from the template is used.
 
 ### `BasicClassifier`
 Classify passages into boolean labels.  Uses a prompt in `basic_classifier_prompt.jinja2` and expects JSON `{label: true/false}` responses.

--- a/src/gabriel/tasks/ratings.py
+++ b/src/gabriel/tasks/ratings.py
@@ -31,7 +31,7 @@ class RatingsConfig:
     n_runs: int = 1
     use_dummy: bool = False
     timeout: float = 60.0
-    rating_scale: str = None,
+    rating_scale: str | None = None
     additional_instructions: str | None = None
 
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -19,6 +19,12 @@ def test_prompt_template():
     assert "desc" in text
 
 
+def test_ratings_default_scale_prompt():
+    tmpl = PromptTemplate.from_package("ratings_prompt.jinja2")
+    rendered = tmpl.render(text="x", attributes=["clarity"], scale=None)
+    assert "All ratings are on a scale" in rendered
+
+
 def test_teleprompter():
     tele = Teleprompter()
     out = tele.generic_elo_prompt(text_circle="a", text_square="b", attributes=["one"], instructions="test")
@@ -144,21 +150,25 @@ def test_prompt_paraphraser_ratings(tmp_path):
 
 def test_api_wrappers(tmp_path):
     df = pd.DataFrame({"txt": ["hello"]})
-    rated = gabriel.rate(
-        df,
-        "txt",
-        attributes={"clarity": ""},
-        save_dir=str(tmp_path / "rate"),
-        use_dummy=True,
+    rated = asyncio.run(
+        gabriel.rate(
+            df,
+            "txt",
+            attributes={"clarity": ""},
+            save_dir=str(tmp_path / "rate"),
+            use_dummy=True,
+        )
     )
     assert "clarity" in rated.columns
 
-    classified = gabriel.classify(
-        df,
-        "txt",
-        labels={"yes": ""},
-        save_dir=str(tmp_path / "cls"),
-        use_dummy=True,
+    classified = asyncio.run(
+        gabriel.classify(
+            df,
+            "txt",
+            labels={"yes": ""},
+            save_dir=str(tmp_path / "cls"),
+            use_dummy=True,
+        )
     )
     assert "yes" in classified.columns
 


### PR DESCRIPTION
## Summary
- fix `RatingsConfig.rating_scale` so `None` works correctly
- document `rating_scale` option in README
- test that default scale text appears when `rating_scale` is `None`
- update API wrapper tests to await async functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688823682e3c833282e1a2da066ef24a