### PR TITLE
Fix dictionary rendering in prompts

### DIFF
--- a/src/gabriel/utils/jinja.py
+++ b/src/gabriel/utils/jinja.py
@@ -1,6 +1,7 @@
 import os
 import random
 from collections import OrderedDict
+import json
 from jinja2 import Environment, FileSystemLoader
 
 
@@ -13,11 +14,12 @@ def shuffled(it, seed=None):
 
 
 def shuffled_dict(d, seed=None):
-    """Return an ordered dict with items shuffled."""
+    """Return a JSON-formatted dict string with items shuffled."""
     items = list(d.items())
     rnd = random.Random(seed) if seed is not None else random
     rnd.shuffle(items)
-    return OrderedDict(items)
+    ordered = OrderedDict(items)
+    return json.dumps(ordered, ensure_ascii=False, indent=2)
 
 
 def get_env():

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -25,6 +25,13 @@ def test_ratings_default_scale_prompt():
     assert "All ratings are on a scale" in rendered
 
 
+def test_shuffled_dict_rendering():
+    tmpl = PromptTemplate.from_package("classification_prompt.jinja2")
+    rendered = tmpl.render(text="x", attributes={"clarity": "Is the text clear?"})
+    assert "OrderedDict" not in rendered
+    assert "{" in rendered and "}" in rendered
+
+
 def test_teleprompter():
     tele = Teleprompter()
     out = tele.generic_elo_prompt(text_circle="a", text_square="b", attributes=["one"], instructions="test")


### PR DESCRIPTION
## Summary
- format shuffled dictionaries as JSON rather than Python `OrderedDict`
- verify prompts show braces instead of `OrderedDict`

## Testing
- `pip install -e .[dev]`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6888256778508332b669d0d13ab60607