### PR TITLE
Prune ratings run cache

### DIFF
--- a/src/gabriel/tasks/ratings.py
+++ b/src/gabriel/tasks/ratings.py
@@ -160,4 +160,15 @@ class Ratings:
         out_path = os.path.splitext(csv_path)[0] + "_final.csv"
         result = df_proc.merge(agg_df, left_on=text_column, right_index=True, how="left")
         result.to_csv(out_path, index=False)
+
+        # remove intermediate run files once everything is saved
+        if self.cfg.n_runs > 1:
+            for idx in range(1, self.cfg.n_runs + 1):
+                path = f"{base_root}_run{idx}{ext}"
+                if os.path.exists(path):
+                    try:
+                        os.remove(path)
+                    except Exception:
+                        pass
+
         return result


### PR DESCRIPTION
## Summary
- scrap temporary run files after Ratings finishes a multirun

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68882b8fc9c88332a57db3e576d439b1