### PR TITLE
Add Rank wrapper and rename task classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,16 +7,16 @@ The current `src` directory contains a cleaned up and asynchronous implementatio
 ## Quick Start
 
 ```python
-from gabriel.tasks import Ratings, RatingsConfig
+from gabriel.tasks import Rate, RateConfig
 
-cfg = RatingsConfig(
+cfg = RateConfig(
     attributes={"clarity": "How understandable is the text?"},
     save_path="ratings.csv",
     use_dummy=True  # set to False to call the OpenAI API
 )
 
 texts = ["This is an example passage"]
-ratings = asyncio.run(Ratings(cfg).run(texts))
+ratings = asyncio.run(Rate(cfg).run(texts))
 print(ratings)
 ```
 
@@ -38,17 +38,17 @@ responses = asyncio.run(
 
 ## Tasks
 
-### `Ratings`
+### `Rate`
 Rate passages on a set of numeric attributes.  The task builds prompts using `gabriel.prompts.ratings_prompt.jinja2` and parses the JSON style output into a `dict` for each passage.
 
-Key options (see `RatingsConfig`):
+Key options (see `RateConfig`):
 - `attributes` – mapping of attribute name to description.
 - `model` – model name (default `o4-mini`).
 - `n_parallels` – number of concurrent API calls.
 - `save_path` – CSV file for intermediate results.
 - `rating_scale` – optional custom rating scale text. If omitted, the default 0–100 scale from the template is used.
 
-### `Classification`
+### `Classify`
 Classify passages into boolean labels.  Uses a prompt in `basic_classifier_prompt.jinja2` and expects JSON `{label: true/false}` responses.
 
 Options include the label dictionary, output directory, model and timeout.  Results are joined back onto the input DataFrame with one column per label.

--- a/src/gabriel/__init__.py
+++ b/src/gabriel/__init__.py
@@ -3,14 +3,14 @@
 from importlib.metadata import PackageNotFoundError, version as _v
 
 from . import tasks as _tasks
-from .api import rate, classify, deidentify
+from .api import rate, classify, deidentify, rank
 
 try:
     __version__ = _v("gabriel")
 except PackageNotFoundError:  # pragma: no cover - package not installed
     from ._version import __version__
 
-__all__ = list(_tasks.__all__) + ["rate", "classify", "deidentify"]
+__all__ = list(_tasks.__all__) + ["rate", "classify", "deidentify", "rank"]
 
 
 def __getattr__(name: str):

--- a/src/gabriel/api.py
+++ b/src/gabriel/api.py
@@ -3,10 +3,12 @@ import os
 import pandas as pd
 
 from .tasks import (
-    Ratings,
-    RatingsConfig,
-    Classification,
-    ClassificationConfig,
+    Rate,
+    RateConfig,
+    Classify,
+    ClassifyConfig,
+    Rank,
+    RankConfig,
     Deidentifier,
     DeidentifyConfig,
 )
@@ -26,9 +28,9 @@ async def rate(
     file_name: str = "ratings.csv",
     **cfg_kwargs,
 ) -> pd.DataFrame:
-    """Convenience wrapper for :class:`gabriel.tasks.Ratings`."""
+    """Convenience wrapper for :class:`gabriel.tasks.Rate`."""
     os.makedirs(save_dir, exist_ok=True)
-    cfg = RatingsConfig(
+    cfg = RateConfig(
         attributes=attributes,
         save_dir=save_dir,
         file_name=file_name,
@@ -39,7 +41,7 @@ async def rate(
         additional_instructions=additional_instructions,
         **cfg_kwargs,
     )
-    return await Ratings(cfg).run(df, column_name, reset_files=reset_files)
+    return await Rate(cfg).run(df, column_name, reset_files=reset_files)
 
 async def classify(
     df: pd.DataFrame,
@@ -56,9 +58,9 @@ async def classify(
     file_name: str = "basic_classifier_responses.csv",
     **cfg_kwargs,
 ) -> pd.DataFrame:
-    """Convenience wrapper for :class:`gabriel.tasks.Classification`."""
+    """Convenience wrapper for :class:`gabriel.tasks.Classify`."""
     os.makedirs(save_dir, exist_ok=True)
-    cfg = ClassificationConfig(
+    cfg = ClassifyConfig(
         labels=labels,
         save_dir=save_dir,
         file_name=file_name,
@@ -69,7 +71,7 @@ async def classify(
         use_dummy=use_dummy,
         **cfg_kwargs,
     )
-    return await Classification(cfg).run(df, column_name, reset_files=reset_files)
+    return await Classify(cfg).run(df, column_name, reset_files=reset_files)
 
 
 async def deidentify(
@@ -101,3 +103,44 @@ async def deidentify(
         **cfg_kwargs,
     )
     return await Deidentifier(cfg).run(df, column_name, grouping_column=grouping_column)
+
+
+async def rank(
+    df: pd.DataFrame,
+    column_name: str,
+    *,
+    attributes: dict[str, str] | list[str],
+    save_dir: str,
+    additional_instructions: str | None = None,
+    model: str = "o4-mini",
+    n_rounds: int = 15,
+    matches_per_round: int = 3,
+    power_matching: bool = True,
+    add_zscore: bool = True,
+    compute_se: bool = True,
+    learning_rate: float = 0.1,
+    n_parallels: int = 100,
+    use_dummy: bool = False,
+    file_name: str = "rankings",
+    reset_files: bool = False,
+    **cfg_kwargs,
+) -> pd.DataFrame:
+    """Convenience wrapper for :class:`gabriel.tasks.Rank`."""
+    os.makedirs(save_dir, exist_ok=True)
+    cfg = RankConfig(
+        attributes=attributes,
+        n_rounds=n_rounds,
+        matches_per_round=matches_per_round,
+        power_matching=power_matching,
+        add_zscore=add_zscore,
+        compute_se=compute_se,
+        learning_rate=learning_rate,
+        model=model,
+        n_parallels=n_parallels,
+        use_dummy=use_dummy,
+        save_dir=save_dir,
+        file_name=file_name,
+        additional_instructions=additional_instructions or "",
+        **cfg_kwargs,
+    )
+    return await Rank(cfg).run(df, column_name, reset_files=reset_files)

--- a/src/gabriel/tasks/__init__.py
+++ b/src/gabriel/tasks/__init__.py
@@ -3,14 +3,16 @@
 from importlib import import_module
 
 _lazy_imports = {
-    "Ratings": ".ratings",
-    "RatingsConfig": ".ratings",
+    "Rate": ".ratings",
+    "RateConfig": ".ratings",
     "Deidentifier": ".deidentification",
     "DeidentifyConfig": ".deidentification",
     "EloRater": ".elo",
     "EloConfig": ".elo",
-    "Classification": ".basic_classifier",
-    "ClassificationConfig": ".basic_classifier",
+    "Classify": ".basic_classifier",
+    "ClassifyConfig": ".basic_classifier",
+    "Rank": ".rank",
+    "RankConfig": ".rank",
     "Regional": ".regional",
     "RegionalConfig": ".regional",
     "RecursiveEloRater": ".recursive_elo",

--- a/src/gabriel/tasks/basic_classifier.py
+++ b/src/gabriel/tasks/basic_classifier.py
@@ -19,8 +19,8 @@ from ..utils import safest_json
 # Configuration dataclass
 # ────────────────────────────
 @dataclass
-class ClassificationConfig:
-    """Configuration for :class:`Classification`."""
+class ClassifyConfig:
+    """Configuration for :class:`Classify`."""
 
     labels: Dict[str, str]  # {"label_name": "description", ...}
     save_dir: str = "classifier"
@@ -37,18 +37,18 @@ class ClassificationConfig:
 # ────────────────────────────
 # Main Basic classifier task
 # ────────────────────────────
-class Classification:
+class Classify:
     """Robust passage classifier using an LLM.
 
-    * Accepts a list of *texts* (not a DataFrame) just like :class:`Ratings`.
+    * Accepts a list of *texts* (not a DataFrame) just like :class:`Rate`.
     * Persists/reads cached responses via the **save_path** attribute (same pattern as
-      :class:`Ratings`).
+      :class:`Rate`).
     """
 
     _FENCE_RE = re.compile(r"```(?:json)?\s*(.*?)\s*```", re.S)
 
     # -----------------------------------------------------------------
-    def __init__(self, cfg: ClassificationConfig, template: PromptTemplate | None = None) -> None:  # noqa: D401,E501
+    def __init__(self, cfg: ClassifyConfig, template: PromptTemplate | None = None) -> None:  # noqa: D401,E501
         self.cfg = cfg
         self.template = template or PromptTemplate.from_package(
             "basic_classifier_prompt.jinja2"
@@ -85,7 +85,7 @@ class Classification:
 
         dup_ct = len(texts) - len(prompts)
         if dup_ct:
-            print(f"[Classification] Skipped {dup_ct} duplicate prompt(s).")
+            print(f"[Classify] Skipped {dup_ct} duplicate prompt(s).")
         return prompts, ids, id_to_rows, id_to_text
 
     # -----------------------------------------------------------------
@@ -197,7 +197,7 @@ class Classification:
 
         if total_orphans:
             print(
-                f"[Classification] WARNING: {total_orphans} response(s) had no matching passage this run."
+                f"[Classify] WARNING: {total_orphans} response(s) had no matching passage this run."
             )
 
         full_df = pd.DataFrame(full_records).set_index(["text", "run"])
@@ -214,7 +214,7 @@ class Classification:
         agg_df = pd.DataFrame({lab: full_df[lab].groupby("text").apply(_mode) for lab in self.cfg.labels})
 
         filled = agg_df.dropna(how="all").shape[0]
-        print(f"[Classification] Filled {filled}/{len(agg_df)} unique texts.")
+        print(f"[Classify] Filled {filled}/{len(agg_df)} unique texts.")
 
         total = len(agg_df)
         print("\n=== Label coverage (non-null) ===")

--- a/src/gabriel/tasks/ratings.py
+++ b/src/gabriel/tasks/ratings.py
@@ -22,7 +22,7 @@ from ..utils import safest_json
 # Configuration dataclass
 # ────────────────────────────
 @dataclass
-class RatingsConfig:
+class RateConfig:
     attributes: Dict[str, str]
     save_dir: str = "ratings"
     file_name: str = "ratings.csv"
@@ -36,14 +36,14 @@ class RatingsConfig:
 
 
 # ────────────────────────────
-# Main Ratings task
+# Main rating task
 # ────────────────────────────
-class Ratings:
+class Rate:
     """Rate passages on specified attributes (0–100)."""
 
 
     # -----------------------------------------------------------------
-    def __init__(self, cfg: RatingsConfig, template: PromptTemplate | None = None) -> None:
+    def __init__(self, cfg: RateConfig, template: PromptTemplate | None = None) -> None:
         self.cfg = cfg
         self.template = template or PromptTemplate.from_package("ratings_prompt.jinja2")
         os.makedirs(self.cfg.save_dir, exist_ok=True)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -4,9 +4,9 @@ import pandas as pd
 from gabriel.core.prompt_template import PromptTemplate
 from gabriel.utils.teleprompter import Teleprompter
 from gabriel.utils import openai_utils
-from gabriel.tasks.ratings import Ratings, RatingsConfig
+from gabriel.tasks.ratings import Rate, RateConfig
 from gabriel.tasks.deidentification import Deidentifier, DeidentifyConfig
-from gabriel.tasks.basic_classifier import Classification, ClassificationConfig
+from gabriel.tasks.basic_classifier import Classify, ClassifyConfig
 from gabriel.tasks.regional import Regional, RegionalConfig
 from gabriel.tasks.county_counter import CountyCounter
 from gabriel.utils import PromptParaphraser, PromptParaphraserConfig
@@ -74,8 +74,8 @@ def test_get_all_responses_images_dummy(tmp_path):
 
 
 def test_ratings_dummy(tmp_path):
-    cfg = RatingsConfig(attributes={"helpfulness": ""}, save_dir=str(tmp_path), file_name="ratings.csv", use_dummy=True)
-    task = Ratings(cfg)
+    cfg = RateConfig(attributes={"helpfulness": ""}, save_dir=str(tmp_path), file_name="ratings.csv", use_dummy=True)
+    task = Rate(cfg)
     data = pd.DataFrame({"text": ["hello"]})
     df = asyncio.run(task.run(data, text_column="text"))
     assert not df.empty
@@ -83,8 +83,8 @@ def test_ratings_dummy(tmp_path):
 
 
 def test_ratings_multirun(tmp_path):
-    cfg = RatingsConfig(attributes={"helpfulness": ""}, save_dir=str(tmp_path), file_name="ratings.csv", use_dummy=True, n_runs=2)
-    task = Ratings(cfg)
+    cfg = RateConfig(attributes={"helpfulness": ""}, save_dir=str(tmp_path), file_name="ratings.csv", use_dummy=True, n_runs=2)
+    task = Rate(cfg)
     data = pd.DataFrame({"text": ["hello"]})
     df = asyncio.run(task.run(data, text_column="text"))
     assert "helpfulness" in df.columns
@@ -101,16 +101,16 @@ def test_deidentifier_dummy(tmp_path):
 
 
 def test_classification_dummy(tmp_path):
-    cfg = ClassificationConfig(labels={"yes": ""}, save_dir=str(tmp_path), use_dummy=True)
-    task = Classification(cfg)
+    cfg = ClassifyConfig(labels={"yes": ""}, save_dir=str(tmp_path), use_dummy=True)
+    task = Classify(cfg)
     df = pd.DataFrame({"txt": ["a", "b"]})
     res = asyncio.run(task.run(df, text_column="txt"))
     assert "yes" in res.columns
 
 
 def test_classification_multirun(tmp_path):
-    cfg = ClassificationConfig(labels={"yes": ""}, save_dir=str(tmp_path), use_dummy=True, n_runs=2)
-    task = Classification(cfg)
+    cfg = ClassifyConfig(labels={"yes": ""}, save_dir=str(tmp_path), use_dummy=True, n_runs=2)
+    task = Classify(cfg)
     df = pd.DataFrame({"txt": ["a"]})
     res = asyncio.run(task.run(df, text_column="txt"))
     assert "yes" in res.columns
@@ -142,7 +142,7 @@ def test_county_counter_dummy(tmp_path):
 
 
 def test_prompt_paraphraser_ratings(tmp_path):
-    cfg = RatingsConfig(
+    cfg = RateConfig(
         attributes={"quality": ""},
         save_dir=str(tmp_path),
         file_name="rat.csv",
@@ -151,7 +151,7 @@ def test_prompt_paraphraser_ratings(tmp_path):
     parap_cfg = PromptParaphraserConfig(n_variants=2, save_dir=str(tmp_path / "para"), use_dummy=True)
     paraphraser = PromptParaphraser(parap_cfg)
     data = pd.DataFrame({"txt": ["hello"]})
-    df = asyncio.run(paraphraser.run(Ratings, cfg, data, text_column="txt"))
+    df = asyncio.run(paraphraser.run(Rate, cfg, data, text_column="txt"))
     assert set(df.prompt_variant) == {"baseline", "variant_1", "variant_2"}
 
 


### PR DESCRIPTION
## Summary
- add `rank` API wrapper for `Rank` task
- rename rating and classification classes to `Rate`/`RateConfig` and `Classify`/`ClassifyConfig`
- update tasks import table and public API
- update README and tests for new names

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889301579d48332a1c2618e568916bc