### PR TITLE
Improve tqdm handling

### DIFF
--- a/legacy_v0/GABRIEL/openai_api_calls.py
+++ b/legacy_v0/GABRIEL/openai_api_calls.py
@@ -9,7 +9,7 @@ import numpy as np
 import os
 from typing import Any, Dict, Optional, List, Tuple
 from aiolimiter import AsyncLimiter
-from tqdm import tqdm
+from tqdm.auto import tqdm
 from concurrent.futures import ThreadPoolExecutor, as_completed
 import tiktoken
 
@@ -394,7 +394,7 @@ class OpenAIClient:
         if save_every_x_seconds is not None:
             periodic_save_task = asyncio.create_task(periodic_save())
 
-        pbar = tqdm(total=total_tasks, desc="Processing prompts")
+        pbar = tqdm(total=total_tasks, desc="Processing prompts", leave=True)
         try:
             while True:
                 await asyncio.sleep(1)

--- a/legacy_v0/build/lib/gabriel/openai_api_calls.py
+++ b/legacy_v0/build/lib/gabriel/openai_api_calls.py
@@ -9,7 +9,7 @@ import numpy as np
 import os
 from typing import Any, Dict, Optional, List, Tuple
 from aiolimiter import AsyncLimiter
-from tqdm import tqdm
+from tqdm.auto import tqdm
 from concurrent.futures import ThreadPoolExecutor, as_completed
 import tiktoken
 
@@ -394,7 +394,7 @@ class OpenAIClient:
         if save_every_x_seconds is not None:
             periodic_save_task = asyncio.create_task(periodic_save())
 
-        pbar = tqdm(total=total_tasks, desc="Processing prompts")
+        pbar = tqdm(total=total_tasks, desc="Processing prompts", leave=True)
         try:
             while True:
                 await asyncio.sleep(1)

--- a/legacy_v0/faceless.py
+++ b/legacy_v0/faceless.py
@@ -5,7 +5,7 @@ import re
 from typing import Any, Dict, List, Optional
 
 import pandas as pd
-from tqdm import tqdm
+from tqdm.auto import tqdm
 from utility_functions import Teleprompter, get_all_responses
 
 

--- a/legacy_v0/utility_functions.py
+++ b/legacy_v0/utility_functions.py
@@ -62,7 +62,7 @@ from sklearn.decomposition import PCA
 from sklearn.metrics import davies_bouldin_score, silhouette_score
 from sklearn.metrics.pairwise import cosine_similarity
 from timeout_decorator import TimeoutError, timeout
-from tqdm import tqdm  #  progress bars
+from tqdm.auto import tqdm  # progress bars that work in notebooks and terminals
 
 
 class APIError(Exception):
@@ -1071,7 +1071,7 @@ async def get_all_responses(
         queue.put_nowait(item)
 
     results, processed = [], 0
-    pbar = tqdm(total=total, desc="Processing prompts")
+    pbar = tqdm(total=total, desc="Processing prompts", leave=True)
 
     async def flush():
         nonlocal results
@@ -1221,7 +1221,7 @@ async def get_all_embeddings(
             queue.task_done()
 
     tasks = [asyncio.create_task(worker()) for _ in range(n_parallels)]
-    pbar = tqdm(total=total_items, desc="Getting embeddings")
+    pbar = tqdm(total=total_items, desc="Getting embeddings", leave=True)
 
     # Periodically update progress bar until workers are done
     while any(not t.done() for t in tasks):

--- a/src/gabriel/utils/openai_utils.py
+++ b/src/gabriel/utils/openai_utils.py
@@ -47,7 +47,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import pandas as pd
 from aiolimiter import AsyncLimiter
-from tqdm import tqdm
+from tqdm.auto import tqdm
 import openai
 import statistics
 
@@ -1040,7 +1040,7 @@ async def get_all_responses(
         queue.put_nowait(item)
     results: List[Dict[str, Any]] = []
     processed = 0
-    pbar = tqdm(total=len(todo_pairs), desc="Processing prompts")
+    pbar = tqdm(total=len(todo_pairs), desc="Processing prompts", leave=True)
 
     async def flush() -> None:
         nonlocal results, df
@@ -1226,4 +1226,5 @@ async def get_all_responses(
         w.cancel()
     await asyncio.gather(*workers, return_exceptions=True)
     await flush()
+    pbar.close()
     return df


### PR DESCRIPTION
## Summary
- use `tqdm.auto.tqdm` for notebook-friendly progress bars
- close progress bars in `openai_utils.get_all_responses`
- update legacy modules to use the auto version

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688930e286588332b21a0ff5ce0b5659