### PR TITLE
Improve JSON parsing

### DIFF
--- a/src/gabriel/utils/parsing.py
+++ b/src/gabriel/utils/parsing.py
@@ -45,6 +45,16 @@ def _parse_json(txt: Any) -> Union[dict, list]:
         except Exception:
             pass
 
+    # attempt to strip `//` and `/* */` style comments before parsing
+    try:
+        no_line_comments = re.sub(r"(?<!:)//.*$", "", cleaned, flags=re.MULTILINE)
+        no_comments = re.sub(r"/\*.*?\*/", "", no_line_comments, flags=re.S)
+        out = json.loads(no_comments)
+        if isinstance(out, (dict, list)):
+            return out
+    except Exception:
+        pass
+
     brace = re.search(r"\{[\s\S]*\}", cleaned)
     if brace:
         try:

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -1,0 +1,20 @@
+import pytest
+from gabriel.utils.parsing import safe_json
+
+
+def test_safe_json_with_comments():
+    raw = (
+        '[\n'
+        '  {\n'
+        '    "name": "Example",\n'
+        '    "links": [\n'
+        '      "https://example.com", // comment\n'
+        '      "s3://bucket/file"  // another comment\n'
+        '    ]\n'
+        '  }\n'
+        ']'
+    )
+    parsed = safe_json(raw)
+    assert isinstance(parsed, list)
+    assert parsed[0]["links"][0] == "https://example.com"
+


### PR DESCRIPTION
## Summary
- enhance safe_json to handle inline and block comments
- test comment parsing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a1f6baa988332b18c00c1dcd353cf