### PR TITLE
Improve safe_json handling of nested list strings

### DIFF
--- a/src/gabriel/utils/parsing.py
+++ b/src/gabriel/utils/parsing.py
@@ -64,6 +64,33 @@ def _parse_json(txt: Any) -> Union[dict, list]:
         except Exception:
             pass
 
+    bracket = re.search(r"\[[\s\S]*\]", cleaned)
+    if bracket:
+        candidate = bracket.group(0).strip()
+        try:
+            out = json.loads(candidate)
+            if isinstance(out, (dict, list)):
+                return out
+        except Exception:
+            pass
+
+        m = re.fullmatch(r"\[\s*(['\"])(.*)\1\s*\]", candidate, re.S)
+        if m:
+            inner = m.group(2).strip()
+            try:
+                out = json.loads(inner)
+                if isinstance(out, (dict, list)):
+                    return out
+            except Exception:
+                inner_bracket = re.search(r"\[[\s\S]*\]", inner)
+                if inner_bracket:
+                    try:
+                        out = json.loads(inner_bracket.group(0))
+                        if isinstance(out, (dict, list)):
+                            return out
+                    except Exception:
+                        pass
+
     raise ValueError(f"Failed to parse JSON: {cleaned[:200]}")
 
 


### PR DESCRIPTION
## Summary
- extend `_parse_json` to parse JSON arrays wrapped in stray quotes or braces
- fall back to inner list detection when initial attempts fail

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a21bed5548332b12e20807258517a