### PR TITLE
Add custom prompt wrapper and refine classify multirun logic

### DIFF
--- a/src/gabriel/__init__.py
+++ b/src/gabriel/__init__.py
@@ -3,14 +3,14 @@
 from importlib.metadata import PackageNotFoundError, version as _v
 
 from . import tasks as _tasks
-from .api import rate, classify, deidentify, rank
+from .api import rate, classify, deidentify, rank, custom_prompt
 
 try:
     __version__ = _v("gabriel")
 except PackageNotFoundError:  # pragma: no cover - package not installed
     from ._version import __version__
 
-__all__ = list(_tasks.__all__) + ["rate", "classify", "deidentify", "rank"]
+__all__ = list(_tasks.__all__) + ["rate", "classify", "deidentify", "rank", "custom_prompt"]
 
 
 def __getattr__(name: str):

--- a/src/gabriel/api.py
+++ b/src/gabriel/api.py
@@ -13,6 +13,7 @@ from .tasks import (
     Deidentifier,
     DeidentifyConfig,
 )
+from .utils.openai_utils import get_all_responses
 
 async def rate(
     df: pd.DataFrame,
@@ -54,6 +55,7 @@ async def classify(
     model: str = "o4-mini",
     n_parallels: int = 400,
     n_runs: int = 1,
+    min_frequency: float = 0.6,
     reset_files: bool = False,
     use_dummy: bool = False,
     file_name: str = "classify_responses.csv",
@@ -68,6 +70,7 @@ async def classify(
         model=model,
         n_parallels=n_parallels,
         n_runs=n_runs,
+        min_frequency=min_frequency,
         additional_instructions=additional_instructions or "",
         use_dummy=use_dummy,
         **cfg_kwargs,
@@ -145,3 +148,32 @@ async def rank(
         **cfg_kwargs,
     )
     return await Rank(cfg).run(df, column_name, reset_files=reset_files)
+
+
+async def custom_prompt(
+    prompts: list[str],
+    identifiers: list[str],
+    *,
+    save_path: str,
+    model: str = "o4-mini",
+    json_mode: bool = False,
+    use_web_search: bool = False,
+    n_parallels: int = 400,
+    use_dummy: bool = False,
+    reset_files: bool = False,
+    **kwargs,
+) -> pd.DataFrame:
+    """Wrapper around :func:`get_all_responses` for arbitrary prompts."""
+    os.makedirs(os.path.dirname(save_path), exist_ok=True)
+    return await get_all_responses(
+        prompts=prompts,
+        identifiers=identifiers,
+        save_path=save_path,
+        model=model,
+        json_mode=json_mode,
+        use_web_search=use_web_search,
+        n_parallels=n_parallels,
+        use_dummy=use_dummy,
+        reset_files=reset_files,
+        **kwargs,
+    )

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -189,3 +189,13 @@ def test_api_wrappers(tmp_path):
     )
     assert "deidentified_text" in deidentified.columns
 
+    custom = asyncio.run(
+        gabriel.custom_prompt(
+            prompts=["hello"],
+            identifiers=["1"],
+            save_path=str(tmp_path / "cust" / "out.csv"),
+            use_dummy=True,
+        )
+    )
+    assert len(custom) == 1
+


### PR DESCRIPTION
## Summary
- add `custom_prompt` API wrapper for direct `get_all_responses` calls
- expose `min_frequency` and use proportion-based aggregation in `Classify`
- export new wrapper from package and extend tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d0db78d0083328e87c7714739071d