### PR TITLE
Integrate passage viewer into package

### DIFF
--- a/src/gabriel/__init__.py
+++ b/src/gabriel/__init__.py
@@ -3,14 +3,22 @@
 from importlib.metadata import PackageNotFoundError, version as _v
 
 from . import tasks as _tasks
-from .api import rate, classify, deidentify, rank, codify, custom_prompt
+from .api import rate, classify, deidentify, rank, codify, custom_prompt, view_coded_passages
 
 try:
     __version__ = _v("gabriel")
 except PackageNotFoundError:  # pragma: no cover - package not installed
     from ._version import __version__
 
-__all__ = list(_tasks.__all__) + ["rate", "classify", "deidentify", "rank", "codify", "custom_prompt"]
+__all__ = list(_tasks.__all__) + [
+    "rate",
+    "classify",
+    "deidentify",
+    "rank",
+    "codify",
+    "custom_prompt",
+    "view_coded_passages",
+]
 
 
 def __getattr__(name: str):

--- a/src/gabriel/api.py
+++ b/src/gabriel/api.py
@@ -15,6 +15,7 @@ from .tasks import (
     Codify,
 )
 from .utils.openai_utils import get_all_responses
+from .utils.passage_viewer import view_coded_passages as _view_coded_passages
 
 async def rate(
     df: pd.DataFrame,
@@ -216,3 +217,12 @@ async def custom_prompt(
         reset_files=reset_files,
         **kwargs,
     )
+
+
+def view_coded_passages(
+    df: pd.DataFrame,
+    text_column: str,
+    categories: Optional[Union[list[str], str]] = None,
+):
+    """Convenience wrapper for the passage viewer utility."""
+    return _view_coded_passages(df, text_column, categories)

--- a/src/gabriel/tasks/codify.py
+++ b/src/gabriel/tasks/codify.py
@@ -1,7 +1,7 @@
 import json
 import os
 import re
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import pandas as pd
 from tqdm import tqdm
@@ -22,6 +22,22 @@ class Codify:
     def __init__(self, teleprompter: Optional[Teleprompter] = None) -> None:
         self.teleprompter = teleprompter or Teleprompter()
         self.hit_rate_stats = {}  # Track hit rates across all texts
+
+    @staticmethod
+    def view(
+        df: pd.DataFrame,
+        text_column: str,
+        categories: Optional[Union[List[str], str]] = None,
+    ):
+        """Convenience wrapper around :func:`view_coded_passages`.
+
+        This helper makes it easy to visualise coding results produced by
+        :class:`Codify`. It simply forwards the provided DataFrame to the
+        passage viewer utility.
+        """
+        from ..utils import view_coded_passages
+
+        return view_coded_passages(df, text_column, categories)
 
     def parse_json(self, response_text: Any) -> Optional[dict]:
         """Parse JSON response, handling various input types."""

--- a/src/gabriel/utils/__init__.py
+++ b/src/gabriel/utils/__init__.py
@@ -8,6 +8,7 @@ from .maps import create_county_choropleth
 from .prompt_paraphraser import PromptParaphraser, PromptParaphraserConfig
 from .parsing import safe_json, safest_json
 from .jinja import shuffled, shuffled_dict, get_env
+from .passage_viewer import PassageViewer, view_coded_passages
 from .word_matching import (
     normalize_text_aggressive,
     letters_only,
@@ -33,4 +34,6 @@ __all__ = [
     "letters_only",
     "robust_find_improved",
     "strict_find",
+    "PassageViewer",
+    "view_coded_passages",
 ]

--- a/src/gabriel/utils/passage_viewer.py
+++ b/src/gabriel/utils/passage_viewer.py
@@ -5,7 +5,10 @@ import random
 import re
 from typing import List, Dict, Any, Optional, Union
 import colorsys
-import matplotlib.pyplot as plt
+try:
+    import matplotlib.pyplot as plt
+except Exception:  # pragma: no cover - optional dependency
+    plt = None
 
 class PassageViewer:
     def __init__(self, df: pd.DataFrame, text_column: str, categories: Optional[Union[List[str], str]] = None):
@@ -42,22 +45,24 @@ class PassageViewer:
     def _generate_distinct_colors(self, n: int) -> List[str]:
         # Use matplotlib tab20 palette for up to 20, then HSV for overflow
         base_colors = []
-        if n <= 20:
-            cmap = plt.get_cmap('tab20')
-            for i in range(n):
-                rgb = cmap(i)[:3]
-                base_colors.append('#{:02x}{:02x}{:02x}'.format(int(rgb[0]*255), int(rgb[1]*255), int(rgb[2]*255)))
-            return base_colors
-        else:
-            cmap = plt.get_cmap('tab20')
-            for i in range(20):
-                rgb = cmap(i)[:3]
-                base_colors.append('#{:02x}{:02x}{:02x}'.format(int(rgb[0]*255), int(rgb[1]*255), int(rgb[2]*255)))
-            for i in range(20, n):
-                hue = (i * 1.0 / n) % 1.0
-                r, g, b = colorsys.hsv_to_rgb(hue, 0.7, 1.0)
-                base_colors.append('#{:02x}{:02x}{:02x}'.format(int(r*255), int(g*255), int(b*255)))
-            return base_colors[:n]
+        if plt is not None:
+            if n <= 20:
+                cmap = plt.get_cmap('tab20')
+                for i in range(n):
+                    rgb = cmap(i)[:3]
+                    base_colors.append('#{:02x}{:02x}{:02x}'.format(int(rgb[0]*255), int(rgb[1]*255), int(rgb[2]*255)))
+                return base_colors
+            else:
+                cmap = plt.get_cmap('tab20')
+                for i in range(20):
+                    rgb = cmap(i)[:3]
+                    base_colors.append('#{:02x}{:02x}{:02x}'.format(int(rgb[0]*255), int(rgb[1]*255), int(rgb[2]*255)))
+        # Fallback or overflow using HSV
+        for i in range(len(base_colors), n):
+            hue = (i * 1.0 / n) % 1.0
+            r, g, b = colorsys.hsv_to_rgb(hue, 0.7, 1.0)
+            base_colors.append('#{:02x}{:02x}{:02x}'.format(int(r*255), int(g*255), int(b*255)))
+        return base_colors[:n]
 
     def _setup_gui(self):
         self.root = tk.Tk()

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,8 +1,15 @@
 from importlib import import_module
 import asyncio
+import pytest
 
 def test_import_gabriel():
     assert import_module("gabriel")
+
+
+def test_viewer_exposed():
+    pytest.importorskip("matplotlib")
+    gabriel = import_module("gabriel")
+    assert callable(gabriel.view_coded_passages)
 
 
 def test_openai_client_dummy():


### PR DESCRIPTION
## Summary
- Add optional matplotlib import and HSV fallback to passage viewer, enabling use without the dependency
- Expose passage viewer through utils, API and top-level module; add Codify.view helper
- Add import test ensuring viewer availability

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d1a82058c8332ab3fe3a18b203acf