### PR TITLE
feat: add colab-safe passage viewer

### DIFF
--- a/src/gabriel/__init__.py
+++ b/src/gabriel/__init__.py
@@ -3,7 +3,16 @@
 from importlib.metadata import PackageNotFoundError, version as _v
 
 from . import tasks as _tasks
-from .api import rate, classify, deidentify, rank, codify, whatever, view_coded_passages
+from .api import (
+    rate,
+    classify,
+    deidentify,
+    rank,
+    codify,
+    whatever,
+    custom_prompt,
+    view_coded_passages,
+)
 
 try:
     __version__ = _v("gabriel")
@@ -17,6 +26,7 @@ __all__ = list(_tasks.__all__) + [
     "rank",
     "codify",
     "whatever",
+    "custom_prompt",
     "view_coded_passages",
 ]
 

--- a/src/gabriel/api.py
+++ b/src/gabriel/api.py
@@ -224,6 +224,37 @@ async def whatever(
     )
 
 
+async def custom_prompt(
+    prompts: list[str],
+    identifiers: list[str],
+    *,
+    save_dir: str,
+    file_name: str = "custom_prompt_responses.csv",
+    model: str = "o4-mini",
+    json_mode: bool = False,
+    use_web_search: bool = False,
+    n_parallels: int = 400,
+    use_dummy: bool = False,
+    reset_files: bool = False,
+    **kwargs,
+) -> pd.DataFrame:
+    """Backward compatible alias for :func:`whatever`."""
+
+    return await whatever(
+        prompts,
+        identifiers,
+        save_dir=save_dir,
+        file_name=file_name,
+        model=model,
+        json_mode=json_mode,
+        use_web_search=use_web_search,
+        n_parallels=n_parallels,
+        use_dummy=use_dummy,
+        reset_files=reset_files,
+        **kwargs,
+    )
+
+
 def view_coded_passages(
     df: pd.DataFrame,
     text_column: str,

--- a/tests/test_colab_viewer.py
+++ b/tests/test_colab_viewer.py
@@ -1,0 +1,12 @@
+import pandas as pd
+import pytest
+
+from gabriel.utils import view_coded_passages
+
+
+def test_view_coded_passages_colab_runs():
+    pytest.importorskip("IPython")
+
+    df = pd.DataFrame({"text": ["A snippet"], "cat": [["A snippet"]]})
+    # Should not raise when using the lightweight HTML viewer
+    view_coded_passages(df, "text", ["cat"], colab=True)


### PR DESCRIPTION
## Summary
- add optional colab parameter with lightweight HTML viewer
- expose custom_prompt API alias
- test colab viewer execution

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e22318c348332840afda4f8b3bf5e