### PR TITLE
feat: expose colab viewer

### DIFF
--- a/src/gabriel/api.py
+++ b/src/gabriel/api.py
@@ -259,6 +259,7 @@ def view_coded_passages(
     df: pd.DataFrame,
     text_column: str,
     categories: Optional[Union[list[str], str]] = None,
+    colab: bool = False,
 ):
     """Convenience wrapper for the passage viewer utility."""
-    return _view_coded_passages(df, text_column, categories)
+    return _view_coded_passages(df, text_column, categories, colab=colab)

--- a/tests/test_colab_viewer.py
+++ b/tests/test_colab_viewer.py
@@ -1,12 +1,21 @@
 import pandas as pd
 import pytest
 
-from gabriel.utils import view_coded_passages
-
 
 def test_view_coded_passages_colab_runs():
     pytest.importorskip("IPython")
+    from gabriel.utils.passage_viewer import view_coded_passages
 
     df = pd.DataFrame({"text": ["A snippet"], "cat": [["A snippet"]]})
     # Should not raise when using the lightweight HTML viewer
     view_coded_passages(df, "text", ["cat"], colab=True)
+
+
+def test_top_level_view_coded_passages_colab_runs():
+    pytest.importorskip("IPython")
+    pytest.importorskip("aiolimiter")
+    pytest.importorskip("openai")
+    import gabriel
+
+    df = pd.DataFrame({"text": ["A snippet"], "cat": [["A snippet"]]})
+    gabriel.view_coded_passages(df, "text", ["cat"], colab=True)


### PR DESCRIPTION
## Summary
- expose the `colab` keyword in `gabriel.view_coded_passages`
- test that top-level and utils entry points handle the Colab viewer

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e2a3886fc8332b0102586ca08a15a