### PR TITLE
feat: add global cooldown and token-aware concurrency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,8 @@ dependencies = [
     "aiolimiter>=1.0.0",
     "plotly>=5.0.0",
     "requests>=2.0.0",
-    "scipy>=1.8.0"
+    "scipy>=1.8.0",
+    "tiktoken>=0.2.0"
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
## Summary
- add `global_cooldown` and token-sample parameters to `get_all_responses`
- implement central retry queue with global cooldown and token-aware parallelism
- log detailed status summary when processing completes
- track per-response input, reasoning, and output token counts

## Testing
- `pytest tests/test_basic.py::test_get_all_responses_dummy -q`


------
https://chatgpt.com/codex/tasks/task_e_689055da6b708332bbe31923dc6cd674