### PR TITLE
Improve timeout estimation and consolidate response logging

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -58,6 +58,8 @@ def test_get_all_responses_dummy(tmp_path):
         use_dummy=True,
     ))
     assert len(df) == 2
+    assert set(["Successful", "Error Log"]).issubset(df.columns)
+    assert df["Successful"].all()
 
 
 def test_get_all_responses_images_dummy(tmp_path):


### PR DESCRIPTION
## Summary
- make dynamic timeout estimator consider in-flight requests so slower calls extend the timeout instead of being cut off early
- record a single row per prompt with `Successful` and `Error Log` fields, deduplicating retries and persisting prior errors
- test to verify new columns and success flag in `get_all_responses`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68920fe71d088332ace438761e98d856