### PR TITLE
Add DataFrame JSON-cleaning utility

### DIFF
--- a/src/gabriel/utils/__init__.py
+++ b/src/gabriel/utils/__init__.py
@@ -6,7 +6,7 @@ from .logging import get_logger, set_log_level
 from .teleprompter import Teleprompter
 from .maps import create_county_choropleth
 from .prompt_paraphraser import PromptParaphraser, PromptParaphraserConfig
-from .parsing import safe_json, safest_json
+from .parsing import safe_json, safest_json, clean_json_df
 from .jinja import shuffled, shuffled_dict, get_env
 from .passage_viewer import PassageViewer, view_coded_passages
 from .word_matching import (
@@ -27,6 +27,7 @@ __all__ = [
     "PromptParaphraserConfig",
     "safe_json",
     "safest_json",
+    "clean_json_df",
     "encode_image",
     "shuffled",
     "shuffled_dict",

--- a/tests/test_clean_json_df.py
+++ b/tests/test_clean_json_df.py
@@ -1,0 +1,10 @@
+import asyncio
+import pandas as pd
+from gabriel.utils import clean_json_df
+
+
+def test_clean_json_df_dummy():
+    df = pd.DataFrame({"col": ['{"a": 1}', "{bad json"]})
+    out = asyncio.run(clean_json_df(df, ["col"], model="dummy"))
+    assert out.loc[0, "col_cleaned"] == '{"a": 1}'
+    assert out.loc[1, "col_cleaned"][0].startswith("DUMMY")


### PR DESCRIPTION
## Summary
- provide `clean_json_df` to repair JSON stored in DataFrame columns via `get_all_responses`
- expose the helper through utils package and test it with dummy model

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893b4c99e6083329cda118ee436e292