### PR TITLE
Handle duplicate DataFrame indices in clean_json_df

### DIFF
--- a/tests/test_clean_json_df.py
+++ b/tests/test_clean_json_df.py
@@ -8,3 +8,10 @@ def test_clean_json_df_dummy():
     out = asyncio.run(clean_json_df(df, ["col"], model="dummy"))
     assert out.loc[0, "col_cleaned"] == '{"a": 1}'
     assert out.loc[1, "col_cleaned"][0].startswith("DUMMY")
+
+
+def test_duplicate_index():
+    df = pd.DataFrame({"col": ['{"a": 1}', "{bad json"]}, index=[0, 0])
+    out = asyncio.run(clean_json_df(df, ["col"], model="dummy"))
+    assert out.iloc[0]["col_cleaned"] == '{"a": 1}'
+    assert out.iloc[1]["col_cleaned"][0].startswith("DUMMY")


### PR DESCRIPTION
## Summary
- Fix `clean_json_df` to assign results using positional indices instead of labels
- Add regression test covering DataFrames with duplicate indices

## Testing
- `pytest tests/test_clean_json_df.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6894da59977083328bbda17df5cabfa4