### PR TITLE
feat: expose save path for clean_json_df

### DIFF
--- a/tests/test_clean_json_df.py
+++ b/tests/test_clean_json_df.py
@@ -15,3 +15,14 @@ def test_duplicate_index():
     out = asyncio.run(clean_json_df(df, ["col"], model="dummy"))
     assert out.iloc[0]["col_cleaned"] == '{"a": 1}'
     assert out.iloc[1]["col_cleaned"][0].startswith("DUMMY")
+
+
+def test_custom_save_path(tmp_path):
+    df = pd.DataFrame({"col": ['{"a": 1}', "{bad json"]})
+    cache_file = tmp_path / "cache.csv"
+    out = asyncio.run(
+        clean_json_df(df, ["col"], model="dummy", save_path=str(cache_file))
+    )
+    assert cache_file.exists()
+    assert out.loc[0, "col_cleaned"] == '{"a": 1}'
+    assert out.loc[1, "col_cleaned"][0].startswith("DUMMY")


### PR DESCRIPTION
## Summary
- allow specifying a path to save the intermediate CSV used by `clean_json_df`
- add tests to ensure custom save path is respected

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68951762ccb88332a858f8e3b5dd7738