### PR TITLE
Fix identifier matching in clean_json_df

### DIFF
--- a/src/gabriel/utils/parsing.py
+++ b/src/gabriel/utils/parsing.py
@@ -227,7 +227,10 @@ async def clean_json_df(
                 except Exception:
                     pass
         for _, row in resp_df.iterrows():
-            col, row_pos = mapping[row["Identifier"]]
+            ident = str(row.get("Identifier", "")).strip()
+            if ident not in mapping:
+                continue
+            col, row_pos = mapping[ident]
             col_idx = df.columns.get_loc(f"{col}_cleaned")
             df.iat[row_pos, col_idx] = row["Response"]
 


### PR DESCRIPTION
## Summary
- handle mismatched identifier types when merging clean_json_df results

## Testing
- `pytest tests/test_clean_json_df.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689519f63e788332a94b15a8b38611d3